### PR TITLE
Minor build fixes for Linux

### DIFF
--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -86,7 +86,7 @@ void FeaturesViewer::reload()
     {
         setLoading(true);
         // load features from file in a seperate thread
-        auto* ioRunnable = new FeatureIORunnable({_folder, _viewId, _describerType});
+        auto* ioRunnable = new FeatureIORunnable(FeatureIORunnable::IOParams(_folder, _viewId, _describerType));
         connect(ioRunnable, &FeatureIORunnable::resultReady, this, &FeaturesViewer::onResultReady);
         QThreadPool::globalInstance()->start(ioRunnable);
     }

--- a/src/FeaturesViewer.hpp
+++ b/src/FeaturesViewer.hpp
@@ -43,7 +43,6 @@ private:
     aliceVision::feature::SIOPointFeature _feat;
 };
 
-Q_DECLARE_METATYPE(Feature);   // for usage in signals/slots
 
 
 /**
@@ -52,11 +51,11 @@ Q_DECLARE_METATYPE(Feature);   // for usage in signals/slots
 class FeatureIORunnable : public QObject, public QRunnable
 {
     Q_OBJECT
-    
+
+public:    
     /// io parameters: folder, viewId, describerType
     using IOParams = std::tuple<QUrl, aliceVision::IndexT, QString>;
 
-public:
     FeatureIORunnable(const IOParams& params):
     _params(params)
     {}
@@ -154,3 +153,5 @@ private:
 };
 
 } // namespace
+
+Q_DECLARE_METATYPE(qtAliceVision::Feature);   // for usage in signals/slots


### PR DESCRIPTION
* move Q_DECLARE_METATYPE outside of qtAliceVision namespace
* make FeatureIORunnable::IOParams public and use it when constructing a FeatureIORunnable