### PR TITLE
[FeaturesViewer] Refactoring data/display from FeaturesViewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,28 @@ MTracks {
 }
 ```
 
+ - Create a `MFeatures` object to get access to all features data:
+
+```js
+MFeatures {
+  viewId: 101245654
+  describerTypes: ["sift", "akaze"]
+  featureFolder: "/path/to/features/folder"
+  mTracks: tracks
+  mSfmData: sfmData
+}
+```
+
  - Create a `FeaturesViewer` to visualize features position, scale, orientation and optionally information about the feature status regarding tracks and SfmData.
 
 ```js
 FeaturesViewer {
     colorOffset: 0
     describerType: "sift"
-    featureFolder: "/path/to/features/folder"
-    mTracks: tracks
-    viewId: 101245654
     color: “blue”
     landmarkColor: “red”
     displayMode: FeaturesViewer.Points
-    mSfmData: sfmData
+    mdescFeatures: mfeatures.allFeatures(describerType)
 }
 ```
 
@@ -95,14 +104,14 @@ MViewStats {
 
 ```js
 FloatImageViewer {
-  source: "/path/to/image”
-  gamma: 1.0f 
+  source: "/path/to/image"
+  gamma: 1.0f
   offset: 0.0f
   width: 500
   height: 540
   paintedWidth: 500
   paintedHeight: 540
-  channelMode: “rgb” 
+  channelMode: “rgb”
 }
 ```
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,8 @@ set(PLUGIN_SOURCES
     MSfMData.cpp MViewStats.cpp
     MTracks.cpp
     FloatImageViewer.cpp FloatTexture.cpp
-    MSfMDataStats.cpp)
+    MSfMDataStats.cpp MFeatures.cpp
+    MDescFeatures.cpp)
 set(PLUGIN_HEADERS
     FeaturesViewer.hpp
     plugin.hpp
@@ -12,12 +13,14 @@ set(PLUGIN_HEADERS
     MTracks.hpp
     MViewStats.hpp
     FloatImageViewer.hpp FloatTexture.hpp
-    MSfMDataStats.hpp)
+    MSfMDataStats.hpp MFeatures.hpp
+    MDescFeatures.hpp)
 set(PLUGIN_MOCS
     FeaturesViewer.hpp MFeature.hpp
     MSfMData.hpp MViewStats.hpp
     MTracks.hpp
-    MSfMDataStats.hpp)
+    MSfMDataStats.hpp MFeatures.hpp
+    MDescFeatures.hpp)
 
 # Target properties
 add_library(qtAliceVisionPlugin SHARED

--- a/src/MDescFeatures.cpp
+++ b/src/MDescFeatures.cpp
@@ -1,0 +1,74 @@
+#include "MDescFeatures.hpp"
+
+#include <QThreadPool>
+#include <QDebug>
+
+namespace qtAliceVision
+{
+
+MDescFeatures::MDescFeatures(const QString& desc, const QUrl& folder, aliceVision::IndexT viewId, QObject* parent) :
+    _describerType(desc), _featureFolder(folder), _viewId(viewId), QObject(parent)
+{
+}
+
+MDescFeatures::~MDescFeatures()
+{
+    qDeleteAll(_features);
+}
+
+void MDescFeatures::reloadFeatures()
+{
+    _nbLandmarks = 0;
+    setReady(false);
+
+    // Make sure to free all the MFeature pointers and to clear the QList.
+    qDeleteAll(_features);
+    _features.clear();
+    Q_EMIT featuresChanged();
+
+    _outdatedFeatures = false;
+
+    if (!_featureFolder.isValid() || _viewId == aliceVision::UndefinedIndexT)
+    {
+        qWarning() << "[QtAliceVision] MDescFeatures::reloadFeatures: No valid folder or view. Describer : " << _describerType;
+        Q_EMIT featuresChanged();
+        return;
+    }
+
+    if (!_loadingFeatures)
+    {
+        setLoadingFeatures(true);
+
+        // load features from file in a seperate thread
+        auto* ioRunnable = new FeatureIORunnable(FeatureIORunnable::IOParams(_featureFolder, _viewId, _describerType));
+        connect(ioRunnable, &FeatureIORunnable::resultReady, this, &MDescFeatures::onFeaturesResultReady);
+        QThreadPool::globalInstance()->start(ioRunnable);
+    }
+    else
+    {
+        // mark current request as outdated
+        _outdatedFeatures = true;
+    }
+}
+
+void MDescFeatures::onFeaturesResultReady(QList<MFeature*> features)
+{
+    // another request has been made while io thread was working
+    if (_outdatedFeatures)
+    {
+        // clear result and reload features from file with current parameters
+        qDeleteAll(features);
+        setLoadingFeatures(false);
+        reloadFeatures();
+        return;
+    }
+
+    // update features
+    _features = features;
+    setLoadingFeatures(false);
+
+    Q_EMIT featuresReadyChanged(_describerType); // Call the updateFeatures slot on the MFeatures instance
+    Q_EMIT featuresChanged();
+}
+
+} // namespace

--- a/src/MDescFeatures.hpp
+++ b/src/MDescFeatures.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "MFeature.hpp"
+
+#include <QObject>
+#include <QQmlListProperty>
+#include <QRunnable>
+#include <QUrl>
+
+namespace qtAliceVision 
+{
+
+/**
+* @brief Contains features data relative to one specific describer type.
+*/
+class MDescFeatures : public QObject
+{
+    Q_OBJECT
+        /// String list of all the describerTypes used. Values comes from QML.
+        Q_PROPERTY(QString describerType MEMBER _describerType NOTIFY describerTypeChanged)
+        /// The list of features
+        Q_PROPERTY(QQmlListProperty<qtAliceVision::MFeature> features READ features NOTIFY featuresChanged)
+        /// Whether features are currently being loaded from file
+        Q_PROPERTY(bool loadingFeatures READ loadingFeatures NOTIFY loadingFeaturesChanged)
+        /// Number of Landmarks
+        Q_PROPERTY(int nbLandmarks MEMBER _nbLandmarks NOTIFY nbLandmarksChanged)
+        /// Number of Tracks
+        Q_PROPERTY(int nbTracks MEMBER _nbTracks NOTIFY nbTracksChanged)
+
+public:
+    explicit MDescFeatures(const QString& desc, const QUrl& folder, aliceVision::IndexT viewId, QObject* parent = nullptr);
+    ~MDescFeatures() override;
+
+    /// Return a QQmlListProperty based on the QList of MFeature.
+    QQmlListProperty<MFeature> features() { return { this, _features }; }
+
+    /// Return the number of landmarks corresponding to this describer.
+    inline int getNbLandmarks() const { return _nbLandmarks; }
+    /// Set the number of landmarks corresponding to this describer.
+    inline void setNbLandmarks(unsigned int nb) { _nbLandmarks = nb; }
+
+    /// Return the number of tracks corresponding to this describer.
+    inline int getNbTracks() const { return _nbTracks; }
+    /// Set the number of tracks corresponding to this describer.
+    inline void setNbTracks(unsigned int nb) { _nbTracks = nb; }
+
+    /// Return a pointer to the QList of MFeature.
+    inline const QList<MFeature*>& getFeaturesData() const { return _features; }
+    /// Set the pointer to the QList of MFeature.
+    void setFeaturesData(const QList<MFeature*>& features)
+    {
+        if (_features == features) return;
+
+        qDeleteAll(_features); // Free memory of the current features
+        _features.clear(); // Clear the list
+        _features = features;
+    }
+
+    /// Return if features are currently loading or not.
+    inline bool loadingFeatures() const { return _loadingFeatures; }
+    /// Set if features are currently loading or not.
+    void setLoadingFeatures(bool loadingFeatures)
+    {
+        if (_loadingFeatures == loadingFeatures)
+            return;
+        _loadingFeatures = loadingFeatures;
+        Q_EMIT loadingFeaturesChanged(); // Useful because it will make QML aware of the loading status
+    }
+
+    /// Return if features are currently ready to be globally updated and displayed.
+    inline bool ready() const { return _ready;  }
+    /// Set if features are currently ready to be globally updated and displayed.
+    void setReady(bool ready) { _ready = ready;  }
+
+    /// Set a new feature folder path.
+    void setFeatureFolder(const QUrl& folder)
+    {
+        if (_featureFolder == folder)
+            return;
+        _featureFolder = folder;
+        reloadFeatures();
+    }
+
+    /// Set a new view id.
+    void setViewId(aliceVision::IndexT id)
+    {
+        if (_viewId == id)
+            return;
+        _viewId = id;
+        reloadFeatures();
+    }
+
+public:
+    Q_SIGNAL void describerTypeChanged();
+    Q_SIGNAL void featuresReadyToDisplayChanged(); // Used to tell the FeaturesWiewer (if there is one) to call the update function
+    Q_SIGNAL void featuresChanged();
+    Q_SIGNAL void loadingFeaturesChanged();
+    Q_SIGNAL void nbLandmarksChanged();
+    Q_SIGNAL void nbTracksChanged();
+    Q_SIGNAL void updateDisplayTracks(bool boolean);
+    Q_SIGNAL void featuresReadyChanged(const QString& desc); // Used to call the updateFeatures slot on the MFeatures instance
+
+private:
+    /// Clean the current features and create a thread to calculate the new ones.
+    void reloadFeatures();
+    /// Handle result from asynchronous file.
+    void onFeaturesResultReady(QList<MFeature*> features);
+
+    bool _loadingFeatures = false;
+    bool _outdatedFeatures = false;
+    bool _ready = false;
+
+    QUrl _featureFolder;
+    aliceVision::IndexT _viewId = aliceVision::UndefinedIndexT;
+    QString _describerType = "sift";
+    QList<MFeature*> _features;
+
+    int _nbLandmarks = 0; // number of features associated to a 3D landmark
+    int _nbTracks = 0; // number of tracks unvalidated after resection
+};
+
+} // namespace

--- a/src/MFeature.hpp
+++ b/src/MFeature.hpp
@@ -6,6 +6,7 @@
 
 #include <aliceVision/sfm/pipeline/regionsIO.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/feature/PointFeature.hpp>
 
 namespace qtAliceVision {
 

--- a/src/MFeatures.cpp
+++ b/src/MFeatures.cpp
@@ -1,0 +1,351 @@
+#include "MFeatures.hpp"
+
+#include <QThreadPool>
+
+namespace qtAliceVision 
+{
+
+MFeatures::MFeatures(QObject* parent):
+    QObject(parent)
+{
+    setupBasicConnections();
+}
+
+MFeatures::~MFeatures()
+{
+    _allFeatures.clear(); // Make sure to clear the Map and free everything inside it 
+}
+
+void MFeatures::setupBasicConnections()
+{
+    // trigger features reload events
+    connect(this, &MFeatures::describerTypesChanged, this, &MFeatures::reloadQMap);
+    connect(this, &MFeatures::featureFolderChanged, this, &MFeatures::updateMapFeatureFolder);
+    connect(this, &MFeatures::viewIdChanged, this, &MFeatures::updateMapViewId);
+
+    // trigger SFM and Tracks updates
+    connect(this, &MFeatures::tracksChanged, this, &MFeatures::updateFeatureFromTracksEmit);
+    connect(this, &MFeatures::sfmDataChanged, this, &MFeatures::updateFeatureFromSfMEmit);
+}
+
+void MFeatures::reloadQMap()
+{
+    // Not sure it is really useful (because we clear the map later) but just in case
+    for (auto i = _allFeatures.constBegin(); i != _allFeatures.constEnd(); ++i)
+    {
+        disconnect(this, &MFeatures::featuresChanged, i.value().get(), &MDescFeatures::featuresReadyToDisplayChanged);
+
+        disconnect(i.value().get(), &MDescFeatures::featuresReadyChanged, this, &MFeatures::updateFeatures);
+        disconnect(i.value().get(), &MDescFeatures::loadingFeaturesChanged, this, &MFeatures::updateLoadingFeatures);
+    }
+
+    _allFeatures.clear(); // Clear the map and delete the MDescFeatures instances
+
+    // Populate the map and connect signals to slots
+    for (const QString& desc : _describerTypes)
+    {
+        QSharedPointer<MDescFeatures> descFeatures(new MDescFeatures(desc, _featureFolder, _viewId));
+        _allFeatures.insert(desc, descFeatures);
+
+        connect(this, &MFeatures::featuresChanged, descFeatures.get(), &MDescFeatures::featuresReadyToDisplayChanged);
+
+        connect(descFeatures.get(), &MDescFeatures::featuresReadyChanged, this, &MFeatures::updateFeatures);
+        connect(descFeatures.get(), &MDescFeatures::loadingFeaturesChanged, this, &MFeatures::updateLoadingFeatures);
+    }
+
+    Q_EMIT mapChanged();
+}
+
+void MFeatures::updateMapFeatureFolder()
+{
+    for (auto i = _allFeatures.constBegin(); i != _allFeatures.constEnd(); ++i)
+    {
+        i.value()->setFeatureFolder(_featureFolder);
+    }
+}
+
+void MFeatures::updateMapViewId()
+{
+    for (auto i = _allFeatures.constBegin(); i != _allFeatures.constEnd(); ++i)
+    {
+        i.value()->setViewId(_viewId);
+    }
+}
+   
+void MFeatures::setMTracks(MTracks* tracks)
+{
+    if (_mtracks == tracks)
+        return;
+    if (_mtracks != nullptr)
+    {
+        disconnect(_mtracks, &MTracks::tracksChanged, this, &MFeatures::tracksChanged);
+    }
+    _mtracks = tracks;
+    if (_mtracks != nullptr)
+    {
+        connect(_mtracks, &MTracks::tracksChanged, this, &MFeatures::tracksChanged);
+    }
+
+    Q_EMIT tracksChanged();
+}
+
+void MFeatures::setMSfmData(MSfMData* sfmData)
+{
+    if (_msfmData == sfmData)
+        return;
+    if (_msfmData != nullptr)
+    {
+        disconnect(_msfmData, &MSfMData::sfmDataChanged, this, &MFeatures::sfmDataChanged);
+    }
+    _msfmData = sfmData;
+    if (_msfmData != nullptr)
+    {
+        connect(_msfmData, &MSfMData::sfmDataChanged, this, &MFeatures::sfmDataChanged);
+    }
+
+    Q_EMIT sfmDataChanged();
+}
+
+void MFeatures::updateFeatures(const QString& desc)
+{
+    updateFeatureFromTracks(desc);
+    updateFeatureFromSfM(desc);
+    _allFeatures.value(desc)->setReady(true);
+    reloadFeatures();
+}
+
+void MFeatures::reloadFeatures()
+{
+    if (!checkAllFeaturesReady()) return; // Return if at least one of the MDescFeatures is not ready
+
+    updateNbTracks();
+    updateTotalNbLandmarks();
+
+    Q_EMIT featuresChanged();
+}
+
+void MFeatures::clearTracksFromFeatures(const QList<MFeature*>& features)
+{
+    for (const auto feature : features)
+    {
+        feature->clearTrack();
+    }
+}
+
+void MFeatures::updateFeatureFromTracks(const QString& desc)
+{
+    QSharedPointer<MDescFeatures> descFeatures = _allFeatures.value(desc);
+    const QList<MFeature*>& features = descFeatures->getFeaturesData();
+
+    if (features.empty())
+        return;
+    clearTracksFromFeatures(features);
+
+    if (_mtracks == nullptr)
+    {
+        qWarning() << "[QtAliceVision] MFeatures::updateFeatureFromTracks: no Track";
+        Q_EMIT descFeatures->updateDisplayTracks(false);
+        return;
+    }
+    if (_mtracks->status() != MTracks::Ready)
+    {
+        qWarning() << "[QtAliceVision] MFeatures::updateFeatureFromTracks: Tracks is not ready: " << _mtracks->status();
+        Q_EMIT descFeatures->updateDisplayTracks(false);
+        return;
+    }
+    if (_mtracks->tracks().empty())
+    {
+        qWarning() << "[QtAliceVision] MFeatures::updateFeatureFromTracks: Tracks is empty";
+        Q_EMIT descFeatures->updateDisplayTracks(false);
+        return;
+    }
+
+    // Update newly loaded features with information from the sfmData
+    aliceVision::feature::EImageDescriberType descType = aliceVision::feature::EImageDescriberType_stringToEnum(desc.toStdString());
+
+    auto tracksPerViewIt = _mtracks->tracksPerView().find(_viewId);
+    if (tracksPerViewIt == _mtracks->tracksPerView().end())
+    {
+        qWarning() << "[QtAliceVision] MFeatures::updateFeatureFromTracks: view does not exist in tracks.";
+        return;
+    }
+    const auto& tracksInCurrentView = tracksPerViewIt->second;
+    const auto& tracks = _mtracks->tracks();
+    for (const auto& trackId : tracksInCurrentView)
+    {
+        const auto& trackIterator = tracks.find(trackId);
+        if (trackIterator == tracks.end())
+        {
+            qWarning() << "[QtAliceVision] MFeatures::updateFeatureFromTracks: Track id: " << trackId << " in current view does not exist in Tracks.";
+            continue;
+        }
+        const aliceVision::track::Track& currentTrack = trackIterator->second;
+
+        if (currentTrack.descType != descType)
+            continue;
+
+        const auto& featIdPerViewIt = currentTrack.featPerView.find(_viewId);
+        if (featIdPerViewIt == currentTrack.featPerView.end())
+        {
+            qWarning() << "[QtAliceVision] MFeatures::updateFeatureFromTracks: featIdPerViewIt invalid.";
+            continue;
+        }
+        const std::size_t featId = featIdPerViewIt->second;
+        if (featId >= features.size())
+        {
+            qWarning() << "[QtAliceVision] MFeatures::updateFeatureFromTracks: featId invalid regarding loaded features.";
+            continue;
+        }
+        MFeature* feature = features.at(featId);
+        feature->setTrackId(trackId);
+    }
+
+    //Q_EMIT descFeatures->updateDisplayTracks(true);
+}
+
+void MFeatures::updateFeatureFromTracksEmit()
+{
+    // Iterate through every MDescFeatures
+    for (auto i = _allFeatures.constBegin(); i != _allFeatures.constEnd(); ++i)
+    {
+        QString desc = i.key();
+        updateFeatureFromTracks(desc);
+    }
+        
+    updateNbTracks();
+    updateTotalNbLandmarks();
+
+    Q_EMIT featuresChanged();
+}
+
+void MFeatures::updateTotalNbLandmarks()
+{
+    _nbLandmarks = 0;
+
+    // Iterate through every MDescFeatures
+    for (auto i = _allFeatures.constBegin(); i != _allFeatures.constEnd(); ++i)
+    {
+        QSharedPointer<MDescFeatures> descFeatures = i.value();
+        _nbLandmarks += descFeatures->getNbLandmarks();
+    }
+}
+
+void MFeatures::updateNbTracks()
+{
+    _nbTracks = 0; // Total number of tracks
+
+    // Iterate through every MDescFeatures
+    for (auto i = _allFeatures.constBegin(); i != _allFeatures.constEnd(); ++i)
+    {
+        unsigned int nbTracksPerDesc = 0; // Local var to count
+
+        QSharedPointer<MDescFeatures> descFeatures = i.value();
+        descFeatures->setNbTracks(0);
+
+        for (MFeature* feature : descFeatures->getFeaturesData())
+        {
+            if (feature->trackId() < 0)
+                continue;
+            ++nbTracksPerDesc;
+        }
+        descFeatures->setNbTracks(nbTracksPerDesc); // Set the number of tracks to each MDescFeatures
+        _nbTracks += nbTracksPerDesc; // Increment the total number of tracks
+    }
+}
+
+void MFeatures::clearSfMFromFeatures(const QList<MFeature*>& features)
+{
+    for (const auto feature : features)
+    {
+        feature->clearLandmarkInfo();
+    }
+}
+
+void MFeatures::updateFeatureFromSfM(const QString& desc)
+{
+    const QList<MFeature*>& features = _allFeatures.value(desc)->getFeaturesData();
+
+    clearSfMFromFeatures(features);
+
+    unsigned int nbLandmarks = 0; // Local variable to count the number of landmarks for those features
+
+    if (features.empty())
+        return;
+    if (_msfmData == nullptr)
+    {
+        qWarning() << "[QtAliceVision] MFeatures::updateFeatureFromSfM: no SfMData";
+        return;
+    }
+    if (_msfmData->status() != MSfMData::Ready)
+    {
+        qWarning() << "[QtAliceVision] MFeatures::updateFeatureFromSfM: SfMData is not ready: " << _msfmData->status();
+        return;
+    }
+    if (_msfmData->rawData().getViews().empty())
+    {
+        qWarning() << "[QtAliceVision] MFeatures::updateFeatureFromSfM: SfMData is empty";
+        return;
+    }
+    const auto viewIt = _msfmData->rawData().getViews().find(_viewId);
+    if (viewIt == _msfmData->rawData().getViews().end())
+    {
+        qWarning() << "[QtAliceVision] MFeatures::updateFeatureFromSfM: View " << _viewId << " is not is the SfMData";
+        return;
+    }
+    const aliceVision::sfmData::View& view = *viewIt->second;
+    if (!_msfmData->rawData().isPoseAndIntrinsicDefined(&view))
+    {
+        qWarning() << "[QtAliceVision] MFeatures::updateFeatureFromSfM: SfMData has no valid pose and intrinsic for view " << _viewId;
+        return;
+    }
+
+    // Update newly loaded features with information from the sfmData
+    aliceVision::feature::EImageDescriberType descType = aliceVision::feature::EImageDescriberType_stringToEnum(desc.toStdString());
+
+    const aliceVision::sfmData::CameraPose pose = _msfmData->rawData().getPose(view);
+    const aliceVision::geometry::Pose3 camTransform = pose.getTransform();
+    const aliceVision::camera::IntrinsicBase* intrinsic = _msfmData->rawData().getIntrinsicPtr(view.getIntrinsicId());
+
+    int numLandmark = 0;
+    for (const auto& landmark : _msfmData->rawData().getLandmarks())
+    {
+        if (landmark.second.descType != descType)
+            continue;
+
+        auto itObs = landmark.second.observations.find(_viewId);
+        if (itObs != landmark.second.observations.end())
+        {
+            // setup landmark id and landmark 2d reprojection in the current view
+            aliceVision::Vec2 r = intrinsic->project(camTransform, landmark.second.X);
+
+            if (itObs->second.id_feat >= 0 && itObs->second.id_feat < features.size())
+            {
+                features.at(itObs->second.id_feat)->setLandmarkInfo(landmark.first, r.cast<float>());
+            }
+            else if (!features.empty())
+            {
+                qWarning() << "[QtAliceVision] ---------- ERROR id_feat: " << itObs->second.id_feat << ", size: " << features.size();
+            }
+
+            ++nbLandmarks;
+        }
+        ++numLandmark;
+    }
+
+    _allFeatures.value(desc)->setNbLandmarks(nbLandmarks); // Set the number of landmarks to the good MDescFeatures
+}
+
+void MFeatures::updateFeatureFromSfMEmit()
+{
+    for (auto i = _allFeatures.constBegin(); i != _allFeatures.constEnd(); ++i)
+    {
+        QString desc = i.key();
+        updateFeatureFromSfM(desc);
+    }
+    updateNbTracks();
+    updateTotalNbLandmarks();
+
+    Q_EMIT featuresChanged();
+}
+
+} // namespace

--- a/src/MFeatures.hpp
+++ b/src/MFeatures.hpp
@@ -1,0 +1,176 @@
+#pragma once
+
+#include "MFeature.hpp"
+#include "MSfMdata.hpp"
+#include "MTracks.hpp"
+#include "MDescFeatures.hpp"
+
+#include <QObject>
+#include <QUrl>
+#include <QSharedPointer>
+
+namespace qtAliceVision 
+{
+
+/**
+* @brief Contains all the data about the features. Contains a map of MDescFeatures.
+*/
+class MFeatures : public QObject
+{
+    Q_OBJECT
+        /// String list of all the describerTypes used. Values comes from QML.
+        Q_PROPERTY(QStringList describerTypes MEMBER _describerTypes NOTIFY describerTypesChanged)
+        /// Path to folder containing the features
+        Q_PROPERTY(QUrl featureFolder MEMBER _featureFolder NOTIFY featureFolderChanged)
+        /// ViewID to consider
+        Q_PROPERTY(quint32 viewId MEMBER _viewId NOTIFY viewIdChanged)
+        /// Pointer to SfmData
+        Q_PROPERTY(qtAliceVision::MSfMData* msfmData READ getMSfmData WRITE setMSfmData NOTIFY sfmDataChanged)
+        /// Pointer to Tracks
+        Q_PROPERTY(qtAliceVision::MTracks* mtracks READ getMTracks WRITE setMTracks NOTIFY tracksChanged)
+        /// The list of features
+        Q_PROPERTY(QVariantMap allFeatures READ allFeatures NOTIFY mapChanged)
+        /// Whether features are currently being loaded from file
+        Q_PROPERTY(bool loadingFeatures READ loadingFeatures NOTIFY loadingFeaturesChanged)
+        /// Whether landmarks are reconstructed
+        Q_PROPERTY(bool haveValidLandmarks READ haveValidLandmarks NOTIFY sfmDataChanged)
+        /// Whether tracks are reconstructed
+        Q_PROPERTY(bool haveValidTracks READ haveValidTracks NOTIFY tracksChanged)
+        /// Number of all the landmarks
+        Q_PROPERTY(unsigned int nbLandmarks READ getNbLandmarks)
+        /// Number of all the tracks
+        Q_PROPERTY(unsigned int nbTracks READ getNbTracks)
+
+public:
+    explicit MFeatures(QObject* parent = nullptr);
+    ~MFeatures() override;
+
+    /// Return a QVariantMap containing the MDescFeatures pointers.
+    QVariantMap allFeatures() const
+    {
+        QVariantMap map;
+        for (auto i = _allFeatures.constBegin(); i != _allFeatures.constEnd(); ++i)
+        {
+            map.insert(i.key(), QVariant::fromValue<MDescFeatures*>(i.value().get()));
+        }
+        return map;
+    }
+
+    /// Return the total number of landmarks.
+    inline unsigned int getNbLandmarks() const { return _nbLandmarks; }
+    /// Return the total number of tracks.
+    inline unsigned int getNbTracks() const { return _nbTracks; }
+
+    /// Return a pointer to SFM Data.
+    inline MSfMData* getMSfmData() const { return _msfmData; }
+    /// Set a pointer to SFM Data.
+    void setMSfmData(MSfMData* sfmData);
+
+    /// Return a pointer to Tracks Data.
+    inline MTracks* getMTracks() const { return _mtracks; }
+    /// Set a pointer to Tracks Data.
+    void setMTracks(MTracks* tracks);
+
+    /// Return a reference to the QMap containing the MDecFeatures pointers.
+    inline const QMap<QString, QSharedPointer<MDescFeatures>>& getAllFeatures() const { return _allFeatures; }
+
+    /// Return if global process is currently loading or not.
+    inline bool loadingFeatures() const { return _loadingFeatures; }
+    /// Return if global process is currently loading or not.
+    void setLoadingFeatures(bool loadingFeatures)
+    {
+        if (_loadingFeatures == loadingFeatures) return;
+        _loadingFeatures = loadingFeatures;
+        Q_EMIT loadingFeaturesChanged();
+    }
+
+    /// Update the global loading features (used in QML). Based on each MDescFeatures own loading status.
+    void updateLoadingFeatures()
+    {
+        _loadingFeatures = false;
+        for (auto i = _allFeatures.constBegin(); i != _allFeatures.constEnd(); ++i)
+        {
+            if (i.value()->loadingFeatures())
+                _loadingFeatures = true;
+                break;
+        }
+        Q_EMIT loadingFeaturesChanged();
+    }
+
+    /// Check if every MDecFeatures is ready to be globally updated and displayed
+    bool checkAllFeaturesReady() const
+    {
+        for (auto i = _allFeatures.constBegin(); i != _allFeatures.constEnd(); ++i)
+        {
+            if (!i.value()->ready()) return false;
+        }
+        return true;
+    }
+         
+    /// Return if landmarks (SFM Data) are valid or not.
+    bool haveValidLandmarks() const { return _msfmData != nullptr && _msfmData->status() == MSfMData::Ready; }
+    /// Return if tracks are valid or not.
+    bool haveValidTracks() const { return _mtracks != nullptr && _mtracks->status() == MTracks::Ready; }
+ 
+public:
+    Q_SIGNAL void sfmDataChanged();
+    Q_SIGNAL void tracksChanged();
+    Q_SIGNAL void featuresChanged();
+    Q_SIGNAL void mapChanged();
+    Q_SIGNAL void viewIdChanged();
+    Q_SIGNAL void featureFolderChanged();
+    Q_SIGNAL void describerTypesChanged();
+    Q_SIGNAL void loadingFeaturesChanged();
+
+private:
+    /// Setup the basic connections between signals and slots.
+    void setupBasicConnections();
+
+    /// Reload the QMap and setup specific connections between signals and slots.
+    void reloadQMap();
+    /// Update feature folder to each MDescFeatures.
+    void updateMapFeatureFolder();
+    /// Update view id to each MDescFeatures.
+    void updateMapViewId();
+
+    /// Update all features.
+    void updateFeatures(const QString& desc);
+    /// Reload all features.
+    void reloadFeatures();
+
+    /// Clear tracks from every feature passed in argument.
+    void clearTracksFromFeatures(const QList<MFeature*>& features);
+    /// Update every feature described by the describer type passed in argument using tracks data.
+    void updateFeatureFromTracks(const QString& desc);
+    /// Update every feature using tracks data. Should be connected to a signal.
+    void updateFeatureFromTracksEmit();
+
+    /**
+    * @brief Update the number of tracks not associated to a landmark. Update number of tracks per describer + total number.
+    * @warning depends on features, landmarks (sfmData), and tracks.
+    */
+    void updateNbTracks();
+    /// Update the total number of landmarks.
+    void updateTotalNbLandmarks();
+
+    /// Clear SFM data from every feature passed in argument.
+    void clearSfMFromFeatures(const QList<MFeature*>& features);
+    /// Update every feature described by the describer type passed in argument using SFM data.
+    void updateFeatureFromSfM(const QString& desc);
+    /// Update every feature using SFM data. Should be connected to a signal.
+    void updateFeatureFromSfMEmit();
+
+
+    QStringList _describerTypes;
+    QUrl _featureFolder;
+    aliceVision::IndexT _viewId = aliceVision::UndefinedIndexT;
+    QMap<QString, QSharedPointer<MDescFeatures>> _allFeatures;
+    MSfMData* _msfmData = nullptr;
+    MTracks* _mtracks = nullptr;
+    bool _loadingFeatures = false;
+
+    int _nbLandmarks = 0; // Total number of features associated to a 3D landmark
+    int _nbTracks = 0; // Total number of tracks unvalidated after resection
+};
+
+} // namespace

--- a/src/plugin.hpp
+++ b/src/plugin.hpp
@@ -31,8 +31,10 @@ public:
         qmlRegisterType<FeaturesViewer>(uri, 1, 0, "FeaturesViewer");
         qmlRegisterType<MSfMData>(uri, 1, 0, "MSfMData");
         qmlRegisterType<MTracks>(uri, 1, 0, "MTracks");
+        qmlRegisterType<MFeatures>(uri, 1, 0, "MFeatures");
         qmlRegisterType<MViewStats>(uri, 1, 0, "MViewStats");
         qmlRegisterType<MSfMDataStats>(uri, 1, 0, "MSfMDataStats");
+        qmlRegisterUncreatableType<MDescFeatures>(uri, 1, 0, "MDescFeatures", "Cannot create MDescFeatures instances from QML.");
         qmlRegisterUncreatableType<MFeature>(uri, 1, 0, "MFeature", "Cannot create Feature instances from QML.");
         qRegisterMetaType<QList<MFeature*>>( "QList<MFeature*>" ); // for usage in signals/slots
         qRegisterMetaType<QList<QPointF*>>("QList<QPointF*>");


### PR DESCRIPTION
- MDescFeatures contains features data relative to one describer type.
- FeaturesViewer handles the display of MDescFeatures data.
- MFeatures contains all MDescFeatures instances.