### PR TITLE
Add missing utils namespace to Histogram usage

### DIFF
--- a/src/MViewStats.cpp
+++ b/src/MViewStats.cpp
@@ -206,14 +206,14 @@ void MViewStats::fillObservationsScaleViewSerie(QXYSeries* observationsScale)
 
 void MViewStats::computeViewStats()
 {
-    _residualHistogramFull = aliceVision::Histogram<double>();
-    _residualHistogramView = aliceVision::Histogram<double>();
+    _residualHistogramFull = aliceVision::utils::Histogram<double>();
+    _residualHistogramView = aliceVision::utils::Histogram<double>();
 
-    _observationsLengthsHistogramFull = aliceVision::Histogram<double>();
-    _observationsLengthsHistogramView = aliceVision::Histogram<double>();
+    _observationsLengthsHistogramFull = aliceVision::utils::Histogram<double>();
+    _observationsLengthsHistogramView = aliceVision::utils::Histogram<double>();
 
-    _observationsScaleHistogramFull = aliceVision::Histogram<double>();
-    _observationsScaleHistogramView = aliceVision::Histogram<double>();
+    _observationsScaleHistogramFull = aliceVision::utils::Histogram<double>();
+    _observationsScaleHistogramView = aliceVision::utils::Histogram<double>();
 
     if(_msfmData == nullptr)
     {

--- a/src/MViewStats.hpp
+++ b/src/MViewStats.hpp
@@ -67,12 +67,12 @@ public:
 
 
 private:
-    aliceVision::Histogram<double> _residualHistogramFull;
-    aliceVision::Histogram<double> _residualHistogramView;
-    aliceVision::Histogram<double> _observationsLengthsHistogramFull;
-    aliceVision::Histogram<double> _observationsLengthsHistogramView;
-    aliceVision::Histogram<double> _observationsScaleHistogramFull;
-    aliceVision::Histogram<double> _observationsScaleHistogramView;
+    aliceVision::utils::Histogram<double> _residualHistogramFull;
+    aliceVision::utils::Histogram<double> _residualHistogramView;
+    aliceVision::utils::Histogram<double> _observationsLengthsHistogramFull;
+    aliceVision::utils::Histogram<double> _observationsLengthsHistogramView;
+    aliceVision::utils::Histogram<double> _observationsScaleHistogramFull;
+    aliceVision::utils::Histogram<double> _observationsScaleHistogramView;
     double _residualMaxAxisX = 0.0;
     double _residualMaxAxisY = 0.0;
     double _observationsLengthsMaxAxisX = 0.0;


### PR DESCRIPTION
As per: https://github.com/alicevision/AliceVision/commit/5883bba9283bed2bfc3e905ed96e395f74f17dd0
the Histogram class now exists as aliceVision::utils::Histogram
rather than aliceVision::Histogram.

This patch updates the namespace to match the new declaration.

Signed-off-by: Alastair D'Silva <alastair@d-silva.org>