### PR TITLE
Correct crash on Windows when opening or switching an image in HDR mode in the Meshroom image viewer.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 project(QtAliceVisionPlugin LANGUAGES CXX VERSION 0.1.0)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # C++14

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,8 @@ set(PLUGIN_HEADERS
     FloatTexture.hpp
     MSfMDataStats.hpp
     PanoramaViewer.hpp
-    Surface.hpp)
+    Surface.hpp
+    ShaderImageViewer.hpp)
 
 set(PLUGIN_MOCS
     FeaturesViewer.hpp

--- a/src/ShaderImageViewer.hpp
+++ b/src/ShaderImageViewer.hpp
@@ -62,7 +62,7 @@ namespace qtAliceVision
                     "    gl_FragColor.b = color[int(channelOrder[2])];                               \n"
                     "    gl_FragColor.a = int(channelOrder[3]) == -1 ? 1.0 : color[int(channelOrder[3])]; \n"
                     "    gl_FragColor.a *= qt_Opacity; \n"
-                    "    if(distance(vec2(vTexCoord.x * aspectRatio ,vTexCoord.y), vec2(fisheyeCircleCoord.x * aspectRatio , fisheyeCircleCoord.y)) > fisheyeCircleRadius && fisheyeCircleRadius > 0) {    \n"
+                    "    if(distance(vec2(vTexCoord.x * aspectRatio ,vTexCoord.y), vec2(fisheyeCircleCoord.x * aspectRatio , fisheyeCircleCoord.y)) > fisheyeCircleRadius && fisheyeCircleRadius > 0.0) {    \n"
                     "       gl_FragColor.a *= 0.001;                                                  \n"
                     "    }                                                                            \n"
                     "    gl_FragColor.rgb *= gl_FragColor.a;                                          \n"


### PR DESCRIPTION
Update src/CMakeList.txt to make ShaderImageViewer.hpp part of the Visual Studio solution.
Update CmakeList.txt by removing useless C++11 setting (C++14 is also set).
Correct float/int type mismatch in comparing value in GL shader embedded within the src/ShaderImageViewer.hpp file.
