### PR TITLE
[Features Viewer] Track reconstruction states

### DIFF
--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -69,8 +69,8 @@ namespace qtAliceVision
 
     QSGGeometry* geometry = nullptr;
 
-    unsigned int kFeatVertices = 0;
-    unsigned int kFeatIndices = 0;
+    int kFeatVertices = 0;
+    int kFeatIndices = 0;
 
     switch (_featureDisplayMode)
     {
@@ -122,7 +122,7 @@ namespace qtAliceVision
     if (params.nbFeaturesToDraw == 0) // nothing to draw or something is not ready
       return;
 
-    unsigned int nbFeaturesDrawn = 0;
+    int nbFeaturesDrawn = 0;
 
     const MFeatures::MViewFeatures* currentViewFeatures = _mfeatures->getCurrentViewFeatures(_describerType);
 
@@ -145,8 +145,8 @@ namespace qtAliceVision
       const auto& feat = feature->pointFeature();
       const float radius = feat.scale();
       const double diag = 2.0 * feat.scale();
-      unsigned int vidx = nbFeaturesDrawn * kFeatVertices;
-      unsigned int iidx = nbFeaturesDrawn * kFeatIndices;
+      int vidx = nbFeaturesDrawn * kFeatVertices;
+      int iidx = nbFeaturesDrawn * kFeatIndices;
 
       if (_featureDisplayMode == FeaturesViewer::Points)
       {
@@ -168,12 +168,12 @@ namespace qtAliceVision
           setVertex(vertices, vidx + 1, tr, _featureColor);
           setVertex(vertices, vidx + 2, br, _featureColor);
           setVertex(vertices, vidx + 3, bl, _featureColor);
-          indices[iidx] = vidx;
-          indices[iidx + 1] = vidx + 1;
-          indices[iidx + 2] = vidx + 2;
-          indices[iidx + 3] = vidx + 2;
-          indices[iidx + 4] = vidx + 3;
-          indices[iidx + 5] = vidx;
+          indices[iidx] = static_cast<unsigned int>(vidx);
+          indices[iidx + 1] = static_cast<unsigned int>(vidx + 1);
+          indices[iidx + 2] = static_cast<unsigned int>(vidx + 2);
+          indices[iidx + 3] = static_cast<unsigned int>(vidx + 2);
+          indices[iidx + 4] = static_cast<unsigned int>(vidx + 3);
+          indices[iidx + 5] = static_cast<unsigned int>(vidx);
         }
         else if (_featureDisplayMode == FeaturesViewer::OrientedSquares)
         {
@@ -184,14 +184,14 @@ namespace qtAliceVision
 
           // create lines, each vertice has to be duplicated (A->B, B->C, C->D, D->A) since we use GL_LINES
           std::vector<QPointF> points = { t.map(tl), t.map(tr), t.map(br), t.map(bl), t.map(tl) };
-          for (unsigned int k = 0; k < points.size(); ++k)
+          for (std::size_t k = 0; k < points.size(); ++k)
           {
-            auto lidx = k * 2; // local index
+            int lidx = static_cast<int>(k) * 2;  // local index
             setVertex(vertices, vidx + lidx, points[k], _featureColor);
             setVertex(vertices, vidx + lidx + 1, points[k + 1], _featureColor);
           }
           // orientation line: up vector (0, 1)
-          const auto nbPoints = static_cast<unsigned int>(points.size());
+          const int nbPoints = static_cast<int>(points.size());
           setVertex(vertices, vidx + nbPoints * 2 - 2, rect.center(), _featureColor);
           auto o2 = t.map(rect.center() - QPointF(0.0f, radius)); // rotate end point
           setVertex(vertices, vidx + nbPoints * 2 - 1, o2, _featureColor);
@@ -205,8 +205,8 @@ namespace qtAliceVision
   {
     qDebug() << "[QtAliceVision] FeaturesViewer: Update paint " << _describerType << " tracks.";
 
-    const unsigned int kLineVertices = 2;
-    const unsigned int kTriangleVertices = 3;
+    const int kLineVertices = 2;
+    const int kTriangleVertices = 3;
 
     const MFeatures::MTrackFeaturesPerTrack* trackFeaturesPerTrack =
         (_displayTracks && params.haveValidFeatures && params.haveValidTracks && params.haveValidLandmarks)
@@ -214,12 +214,12 @@ namespace qtAliceVision
     const aliceVision::IndexT currentFrameId = (trackFeaturesPerTrack != nullptr)
         ? _mfeatures->getCurrentFrameId() : aliceVision::UndefinedIndexT;
 
-    std::size_t nbTracksToDraw = 0;
-    std::size_t nbTrackLinesToDraw[3] = {0, 0, 0};
-    std::size_t nbReprojectionErrorLinesToDraw = 0;
-    std::size_t nbPointsToDraw = 0;
-    std::size_t nbHighlightPointsToDraw = 0;
-    std::size_t nbEndpointsToDraw = 0;
+    int nbTracksToDraw = 0;
+    int nbTrackLinesToDraw[3] = {0, 0, 0};
+    int nbReprojectionErrorLinesToDraw = 0;
+    int nbPointsToDraw = 0;
+    int nbHighlightPointsToDraw = 0;
+    int nbEndpointsToDraw = 0;
 
     if (trackFeaturesPerTrack != nullptr)
     {
@@ -251,7 +251,7 @@ namespace qtAliceVision
 
         const MFeatures::ReconstructionState state = globalTrackInfo.reconstructionState();
         const int stateIdx = static_cast<int>(state);
-        nbTrackLinesToDraw[stateIdx] += (trackFeatures.featuresPerFrame.size() - 1);  // number of lines in the track
+        nbTrackLinesToDraw[stateIdx] += static_cast<int>(trackFeatures.featuresPerFrame.size()) - 1;  // number of lines in the track
         
         if (_trackDisplayMode == WithCurrentMatches)
         {
@@ -268,12 +268,12 @@ namespace qtAliceVision
         {
           const auto it = trackFeatures.featuresPerFrame.find(currentFrameId);
           if (it != trackFeatures.featuresPerFrame.end())
-            ++nbHighlightPointsToDraw; // to draw a highlight point in order to identify the current match
+            ++nbHighlightPointsToDraw;  // to draw a highlight point in order to identify the current match
           
           if (trackFeatures.nbLandmarks > 0)
-            nbReprojectionErrorLinesToDraw += trackFeatures.featuresPerFrame.size(); // one line per matches for rerojection error
+            nbReprojectionErrorLinesToDraw += static_cast<int>(trackFeatures.featuresPerFrame.size());  // one line per matches for reprojection error
 
-          nbPointsToDraw += trackFeatures.featuresPerFrame.size(); // one point per matches
+          nbPointsToDraw += static_cast<int>(trackFeatures.featuresPerFrame.size());  // one point per matches
         }
 
         if (_displayTrackEndpoints)
@@ -314,8 +314,8 @@ namespace qtAliceVision
       // (2) Highlight points
       geometryHighlightPoint = getCleanChildGeometry(node, 2, nbHighlightPointsToDraw);
       // (3) Tracks lines
-      for (std::size_t idx = 0; idx < 3; idx++) 
-        geometryTrackLine[idx] = getCleanChildGeometry(node, idx+3, nbTrackLinesToDraw[idx] * kLineVertices);
+      for (std::size_t idx = 0; idx < 3; idx++)
+        geometryTrackLine[idx] = getCleanChildGeometry(node, static_cast<int>(idx+3), nbTrackLinesToDraw[idx] * kLineVertices);
       // (4) Reprojection Error lines
       geometryReprojectionErrorLine = getCleanChildGeometry(node, 6, nbReprojectionErrorLinesToDraw * kLineVertices);
       // (5) Points
@@ -344,8 +344,8 @@ namespace qtAliceVision
 
     QSGGeometry::ColoredPoint2D* verticesHighlightPoints = geometryHighlightPoint->vertexDataAsColoredPoint2D();
     QSGGeometry::ColoredPoint2D* verticesTrackLines[3] = {
-      geometryTrackLine[0]->vertexDataAsColoredPoint2D(), 
-      geometryTrackLine[1]->vertexDataAsColoredPoint2D(), 
+      geometryTrackLine[0]->vertexDataAsColoredPoint2D(),
+      geometryTrackLine[1]->vertexDataAsColoredPoint2D(),
       geometryTrackLine[2]->vertexDataAsColoredPoint2D()
     };
     QSGGeometry::ColoredPoint2D* verticesReprojectionErrorLines = geometryReprojectionErrorLine->vertexDataAsColoredPoint2D();
@@ -396,9 +396,9 @@ namespace qtAliceVision
                                       aliceVision::IndexT frameId,
                                       const MFeature* feature,
                                       const QColor& color,
-                                      unsigned int& nbReprojectionErrorLinesDrawn,
-                                      unsigned int& nbHighlightPointsDrawn,
-                                      unsigned int& nbPointsDrawn,
+                                      int& nbReprojectionErrorLinesDrawn,
+                                      int& nbHighlightPointsDrawn,
+                                      int& nbPointsDrawn,
                                       bool trackHasInliers)
     {
       if (_trackDisplayMode == WithAllMatches || (frameId == curFrameId && _trackDisplayMode == WithCurrentMatches))
@@ -421,7 +421,7 @@ namespace qtAliceVision
         // draw reprojection error for landmark
         if (trackHasInliers)
         {
-          const unsigned vIdx = nbReprojectionErrorLinesDrawn * kLineVertices;
+          const int vIdx = nbReprojectionErrorLinesDrawn * kLineVertices;
           setVertex(verticesReprojectionErrorLines, vIdx, point2d, color);
           setVertex(verticesReprojectionErrorLines, vIdx + 1, point3d, color);
           ++nbReprojectionErrorLinesDrawn;
@@ -430,17 +430,17 @@ namespace qtAliceVision
     };
 
     // utility lambda to register an oriented triangle corresponding to an endpoint
-    const auto drawEndpoint = [&](const QPointF& pointFrom, 
-                                  const QPointF& pointTo, 
-                                  const QColor& color, 
-                                  unsigned int& nbEndpointsDrawn, 
+    const auto drawEndpoint = [&](const QPointF& pointFrom,
+                                  const QPointF& pointTo,
+                                  const QColor& color,
+                                  int& nbEndpointsDrawn,
                                   float size = 10.f)
     {
         QPointF triangle[] = {QPointF(0, 0), QPointF(-2, 1), QPointF(-2, -1)};
-        float angle = QLineF(pointFrom, pointTo).angle() - rotation();
+        double angle = QLineF(pointFrom, pointTo).angle() - rotation();
         auto tr = QTransform().rotate(-angle).scale(size, size);
         const int vIdx = nbEndpointsDrawn * kTriangleVertices;
-        for (int i = 0; i < kTriangleVertices; i++) 
+        for (int i = 0; i < kTriangleVertices; i++)
             setVertex(verticesEndpoints, vIdx + i, pointFrom + tr.map(triangle[i]), color);
         nbEndpointsDrawn++;
     };
@@ -455,11 +455,11 @@ namespace qtAliceVision
       return;
     }
 
-    unsigned int nbHighlightPointsDrawn = 0;
-    unsigned int nbTrackLinesDrawn[3] = {0, 0, 0};
-    unsigned int nbReprojectionErrorLinesDrawn = 0;
-    unsigned int nbPointsDrawn = 0;
-    unsigned int nbEndpointsDrawn = 0;
+    int nbHighlightPointsDrawn = 0;
+    int nbTrackLinesDrawn[3] = {0, 0, 0};
+    int nbReprojectionErrorLinesDrawn = 0;
+    int nbPointsDrawn = 0;
+    int nbEndpointsDrawn = 0;
 
     for (const auto& trackFeaturesPair : *trackFeaturesPerTrack)
     {
@@ -522,7 +522,7 @@ namespace qtAliceVision
 
           // draw track line
           const QColor  lineColor = getLineColor(contiguous, inliers, trackHasInliers);
-          unsigned int vIdx = nbTrackLinesDrawn[stateIdx] * kLineVertices;
+          int vIdx = nbTrackLinesDrawn[stateIdx] * kLineVertices;
 
           QPointF prevPoint;
           QPointF curPoint;
@@ -588,7 +588,7 @@ namespace qtAliceVision
     if (params.nbMatchesToDraw == 0) // nothing to draw or something is not ready
       return;
 
-    unsigned int nbMatchesDrawn = 0;
+    int nbMatchesDrawn = 0;
 
     const MFeatures::MViewFeatures* currentViewFeatures = _mfeatures->getCurrentViewFeatures(_describerType);
 
@@ -621,7 +621,7 @@ namespace qtAliceVision
   {
     qDebug() << "[QtAliceVision] FeaturesViewer: Update paint " << _describerType << " landmarks.";
 
-    const unsigned int kReprojectionVertices = 2;
+    const int kReprojectionVertices = 2;
 
     QSGGeometry* geometryLine = nullptr;
     QSGGeometry* geometryPoint = nullptr;
@@ -649,7 +649,7 @@ namespace qtAliceVision
     if (params.nbLandmarksToDraw == 0) // nothing to draw or something is not ready
       return;
 
-    unsigned int nbLandmarksDrawn = 0;
+    int nbLandmarksDrawn = 0;
 
     const MFeatures::MViewFeatures* currentViewFeatures = _mfeatures->getCurrentViewFeatures(_describerType);
     const QColor reprojectionColor = _landmarkColor.darker(150);
@@ -673,7 +673,7 @@ namespace qtAliceVision
           break;
         }
 
-        const unsigned int vidx = nbLandmarksDrawn * kReprojectionVertices;
+        const int vidx = nbLandmarksDrawn * kReprojectionVertices;
         setVertex(verticesLines, vidx, QPointF(feature->x(), feature->y()), reprojectionColor);
         setVertex(verticesLines, vidx + 1, QPointF(feature->rx(), feature->ry()), reprojectionColor);
         setVertex(verticesPoints, nbLandmarksDrawn, QPointF(feature->rx(), feature->ry()), _landmarkColor);
@@ -795,9 +795,14 @@ namespace qtAliceVision
     return geometry;
   }
 
-  void FeaturesViewer::setVertex(QSGGeometry::ColoredPoint2D* vertices, unsigned int idx, const QPointF& point, const QColor& c)
+  void FeaturesViewer::setVertex(QSGGeometry::ColoredPoint2D* vertices, int idx, const QPointF& point, const QColor& c)
   {
-    vertices[idx].set(point.x(), point.y(), c.red(), c.green(), c.blue(), c.alpha());
+    vertices[idx].set(static_cast<float>(point.x()),
+                      static_cast<float>(point.y()),
+                      static_cast<unsigned char>(c.red()),
+                      static_cast<unsigned char>(c.green()),
+                      static_cast<unsigned char>(c.blue()),
+                      static_cast<unsigned char>(c.alpha()));
   }
 
 } // namespace qtAliceVision

--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -226,6 +226,7 @@ namespace qtAliceVision
       for (const auto& trackFeaturesPair : *trackFeaturesPerTrack)
       {
         const auto& trackFeatures = trackFeaturesPair.second;
+        const auto& globalTrackInfo = _mfeatures->globalTrackInfo(trackFeaturesPair.first);
 
         // feature scale filter
         if (trackFeatures.featureScaleAverage > params.maxFeatureScale ||
@@ -240,9 +241,14 @@ namespace qtAliceVision
           continue;
         }
 
+        // track frame interval contains current frame
+        if (currentFrameId < globalTrackInfo.startFrameId || currentFrameId > globalTrackInfo.endFrameId)
+        {
+            continue;
+        }
+
         ++nbTracksToDraw;
 
-        const auto& globalTrackInfo = _mfeatures->globalTrackInfo(trackFeaturesPair.first);
         const int state = globalTrackInfo.reconstructionState();
         nbTrackLinesToDraw[state] += (trackFeatures.featuresPerFrame.size() - 1); // number of lines in the track
         
@@ -447,6 +453,7 @@ namespace qtAliceVision
     for (const auto& trackFeaturesPair : *trackFeaturesPerTrack)
     {
       const auto& trackFeatures = trackFeaturesPair.second;
+      const auto& globalTrackInfo = _mfeatures->globalTrackInfo(trackFeaturesPair.first);
 
       // feature scale filter
       if (trackFeatures.featureScaleAverage > params.maxFeatureScale ||
@@ -461,7 +468,12 @@ namespace qtAliceVision
         continue;
       }
 
-      const auto& globalTrackInfo = _mfeatures->globalTrackInfo(trackFeaturesPair.first);
+      // track frame interval contains current frame
+      if (currentFrameId < globalTrackInfo.startFrameId || currentFrameId > globalTrackInfo.endFrameId)
+      {
+          continue;
+      }
+
       const int state = globalTrackInfo.reconstructionState();
       const bool trackHasInliers = (state != 0);
 

--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -413,6 +413,21 @@ namespace qtAliceVision
       }
     };
 
+    // utility lambda to register an oriented triangle corresponding to an endpoint
+    const auto drawEndpoint = [&](const QPointF& pointFrom, 
+                                  const QPointF& pointTo, 
+                                  unsigned int& nbEndpointsDrawn, 
+                                  float size = 10.f)
+    {
+        QPointF triangle[] = {QPointF(0, 0), QPointF(-2, 1), QPointF(-2, -1)};
+        float angle = QLineF(pointFrom, pointTo).angle() - rotation();
+        auto tr = QTransform().rotate(-angle).scale(size, size);
+        const int vIdx = nbEndpointsDrawn * kTriangleVertices;
+        for (int i = 0; i < kTriangleVertices; i++) 
+            setVertex(verticesEndpoints, vIdx + i, pointFrom + tr.map(triangle[i]), _endpointColor);
+        nbEndpointsDrawn++;
+    };
+
     if (nbTracksToDraw == 0)
       return;
 
@@ -509,29 +524,11 @@ namespace qtAliceVision
           {
             // draw global start point
             if (previousFrameId == globalTrackInfo.startFrameId)
-            {
-              vIdx = nbEndpointsDrawn * kTriangleVertices;
-              QPointF triangle[] = {QPointF(1, 0), QPointF(-1, 1), QPointF(-1, -1)};
-              float angle = QLineF(curPoint, prevPoint).angle() - rotation();
-              float size = 10.f;
-              auto tr = QTransform().rotate(180 - angle).scale(size, size);
-              for (int i = 0; i < kTriangleVertices; i++) 
-                setVertex(verticesEndpoints, vIdx + i, prevPoint + tr.map(triangle[i]), _endpointColor);
-              nbEndpointsDrawn++;
-            }
+                drawEndpoint(prevPoint, curPoint, nbEndpointsDrawn);
 
             // draw global end point
             if (frameId == globalTrackInfo.endFrameId)
-            {
-              vIdx = nbEndpointsDrawn * kTriangleVertices;
-              QPointF triangle[] = {QPointF(1, 0), QPointF(-1, 1), QPointF(-1, -1)};
-              float angle = QLineF(curPoint, prevPoint).angle() - rotation();
-              float size = 10.f;
-              auto tr = QTransform().rotate(-angle).scale(size, size);
-              for (int i = 0; i < kTriangleVertices; i++) 
-                setVertex(verticesEndpoints, vIdx + i, curPoint + tr.map(triangle[i]), _endpointColor);
-              nbEndpointsDrawn++;
-            }
+                drawEndpoint(curPoint, prevPoint, nbEndpointsDrawn);
           }
         }
 

--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -288,31 +288,31 @@ namespace qtAliceVision
 
     if (node->childCount() < 8)
     {
-      // (1) Highlight points
+      // (1) Endpoints
+      geometryEndpoint = appendChildGeometry(node, nbEndpointsToDraw);
+      // (2) Highlight points
       geometryHighlightPoint = appendChildGeometry(node, nbHighlightPointsToDraw);
-      // (2) Track lines
+      // (3) Track lines
       for (std::size_t idx = 0; idx < 3; idx++)
         geometryTrackLine[idx] = appendChildGeometry(node, nbTrackLinesToDraw[idx] * kLineVertices);
-      // (3) Reprojection Error lines
+      // (4) Reprojection Error lines
       geometryReprojectionErrorLine = appendChildGeometry(node, nbReprojectionErrorLinesToDraw * kLineVertices);
-      // (4) Points
+      // (5) Points
       geometryPoint = appendChildGeometry(node, nbPointsToDraw);
-      // (5) Endpoints
-      geometryEndpoint = appendChildGeometry(node, nbEndpointsToDraw);
     }
     else
     {
-      // (1) Highlight points
-      geometryHighlightPoint = getCleanChildGeometry(node, 1, nbHighlightPointsToDraw);
-      // (2) Tracks lines
+      // (1) Endpoints
+      geometryEndpoint = getCleanChildGeometry(node, 1, nbEndpointsToDraw * kTriangleVertices);
+      // (2) Highlight points
+      geometryHighlightPoint = getCleanChildGeometry(node, 2, nbHighlightPointsToDraw);
+      // (3) Tracks lines
       for (std::size_t idx = 0; idx < 3; idx++) 
-        geometryTrackLine[idx] = getCleanChildGeometry(node, idx+2, nbTrackLinesToDraw[idx] * kLineVertices);
-      // (3) Reprojection Error lines
-      geometryReprojectionErrorLine = getCleanChildGeometry(node, 5, nbReprojectionErrorLinesToDraw * kLineVertices);
-      // (4) Points
-      geometryPoint = getCleanChildGeometry(node, 6, nbPointsToDraw);
-      // (5) Endpoints
-      geometryEndpoint = getCleanChildGeometry(node, 7, nbEndpointsToDraw * kTriangleVertices);
+        geometryTrackLine[idx] = getCleanChildGeometry(node, idx+3, nbTrackLinesToDraw[idx] * kLineVertices);
+      // (4) Reprojection Error lines
+      geometryReprojectionErrorLine = getCleanChildGeometry(node, 6, nbReprojectionErrorLinesToDraw * kLineVertices);
+      // (5) Points
+      geometryPoint = getCleanChildGeometry(node, 7, nbPointsToDraw);
     }
 
     geometryHighlightPoint->setDrawingMode(QSGGeometry::DrawPoints);

--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -239,7 +239,8 @@ namespace qtAliceVision
 
         ++nbTracksToDraw;
 
-        int state = _mfeatures->trackReconstructionState(trackFeaturesPair.first);
+        const auto& globalTrackInfo = _mfeatures->globalTrackInfo(trackFeaturesPair.first);
+        const int state = globalTrackInfo.reconstructionState();
         nbTrackLinesToDraw[state] += (trackFeatures.featuresPerFrame.size() - 1); // number of lines in the track
         
         if (_trackDisplayMode == WithCurrentMatches)
@@ -424,7 +425,8 @@ namespace qtAliceVision
         continue;
       }
 
-      const int state = _mfeatures->trackReconstructionState(trackFeaturesPair.first);
+      const auto& globalTrackInfo = _mfeatures->globalTrackInfo(trackFeaturesPair.first);
+      const int state = globalTrackInfo.reconstructionState();
       const bool trackHasInliers = (state != 0);
 
       const MFeature* previousFeature = nullptr;

--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -413,8 +413,9 @@ namespace qtAliceVision
         {
           QColor colorHighlight = QColor(200, 200, 200);
           if (color.alpha() == 0)
-            colorHighlight = QColor(0, 0, 0, 0); // color should be rgba(0,0,0,0) in order to be transparent.
-          setVertex(verticesHighlightPoints, nbHighlightPointsDrawn, (_display3dTracks && trackHasInliers) ? point3d : point2d, colorHighlight);
+            colorHighlight = QColor(0, 0, 0, 0);  // color should be rgba(0,0,0,0) in order to be transparent.
+          setVertex(verticesHighlightPoints, nbHighlightPointsDrawn,
+                    (_display3dTracks && trackHasInliers) ? point3d : point2d, colorHighlight);
           ++nbHighlightPointsDrawn;
         }
 
@@ -422,8 +423,9 @@ namespace qtAliceVision
         if (trackHasInliers)
         {
           const int vIdx = nbReprojectionErrorLinesDrawn * kLineVertices;
-          setVertex(verticesReprojectionErrorLines, vIdx, point2d, color);
-          setVertex(verticesReprojectionErrorLines, vIdx + 1, point3d, color);
+          const QColor reprojectionColor = _landmarkColor.darker(150);
+          setVertex(verticesReprojectionErrorLines, vIdx, point2d, reprojectionColor);
+          setVertex(verticesReprojectionErrorLines, vIdx + 1, point3d, reprojectionColor);
           ++nbReprojectionErrorLinesDrawn;
         }
       }
@@ -513,12 +515,19 @@ namespace qtAliceVision
           const bool inliers = previousFeatureInlier && currentFeatureInlier;
 
           // draw previous point
-          const QColor previousPointColor = getPointColor(contiguous || previousTrackLineContiguous, previousFeatureInlier, trackHasInliers);
-          drawFeaturePoint(currentFrameId, previousFrameId, previousFeature, previousPointColor, nbReprojectionErrorLinesDrawn, nbHighlightPointsDrawn, nbPointsDrawn, trackFeatures.nbLandmarks > 0);
+          const QColor previousPointColor = getPointColor(contiguous || previousTrackLineContiguous,
+                                                          previousFeatureInlier, trackHasInliers);
+          drawFeaturePoint(currentFrameId,
+                           previousFrameId, previousFeature, previousPointColor,
+                           nbReprojectionErrorLinesDrawn, nbHighlightPointsDrawn, nbPointsDrawn,
+                           trackFeatures.nbLandmarks > 0);
 
           // draw track last point
           if (frameId == trackFeatures.maxFrameId)
-            drawFeaturePoint(currentFrameId, frameId, feature, getPointColor(contiguous, currentFeatureInlier, trackHasInliers), nbReprojectionErrorLinesDrawn, nbHighlightPointsDrawn, nbPointsDrawn, trackFeatures.nbLandmarks > 0);
+            drawFeaturePoint(currentFrameId,
+                             frameId, feature, getPointColor(contiguous, currentFeatureInlier, trackHasInliers),
+                             nbReprojectionErrorLinesDrawn, nbHighlightPointsDrawn, nbPointsDrawn,
+                             trackFeatures.nbLandmarks > 0);
 
           // draw track line
           const QColor  lineColor = getLineColor(contiguous, inliers, trackHasInliers);
@@ -526,12 +535,12 @@ namespace qtAliceVision
 
           QPointF prevPoint;
           QPointF curPoint;
-          if (_display3dTracks && trackHasInliers) // 3d track line
+          if (_display3dTracks && trackHasInliers)  // 3d track line
           {
             prevPoint = QPointF(previousFeature->rx(), previousFeature->ry());
             curPoint = QPointF(feature->rx(), feature->ry());
           }
-          else // 2d track line
+          else  // 2d track line
           {
             prevPoint = QPointF(previousFeature->x(), previousFeature->y());
             curPoint = QPointF(feature->x(), feature->y());
@@ -585,7 +594,7 @@ namespace qtAliceVision
 
     QSGGeometry::ColoredPoint2D* verticesPoints = geometryPoint->vertexDataAsColoredPoint2D();
 
-    if (params.nbMatchesToDraw == 0) // nothing to draw or something is not ready
+    if (params.nbMatchesToDraw == 0)  // nothing to draw or something is not ready
       return;
 
     int nbMatchesDrawn = 0;

--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -712,7 +712,7 @@ namespace qtAliceVision
     if (!_displayFeatures)
       params.nbFeaturesToDraw = 0;
 
-    if (!_displayMatches || !params.haveValidTracks || !params.haveValidLandmarks)
+    if (!_displayMatches || !params.haveValidTracks)
       params.nbMatchesToDraw = 0;
 
     if (!_displayLandmarks || !params.haveValidLandmarks)

--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -249,8 +249,9 @@ namespace qtAliceVision
 
         ++nbTracksToDraw;
 
-        const int state = globalTrackInfo.reconstructionState();
-        nbTrackLinesToDraw[state] += (trackFeatures.featuresPerFrame.size() - 1); // number of lines in the track
+        const MFeatures::ReconstructionState state = globalTrackInfo.reconstructionState();
+        const int stateIdx = static_cast<int>(state);
+        nbTrackLinesToDraw[stateIdx] += (trackFeatures.featuresPerFrame.size() - 1);  // number of lines in the track
         
         if (_trackDisplayMode == WithCurrentMatches)
         {
@@ -258,7 +259,7 @@ namespace qtAliceVision
           if (it != trackFeatures.featuresPerFrame.end())
           {
             if (trackFeatures.nbLandmarks > 0)
-              ++nbReprojectionErrorLinesToDraw; // to draw rerojection error
+              ++nbReprojectionErrorLinesToDraw;  // to draw reprojection error
             ++nbPointsToDraw;
             ++nbHighlightPointsToDraw;
           }
@@ -268,7 +269,7 @@ namespace qtAliceVision
           const auto it = trackFeatures.featuresPerFrame.find(currentFrameId);
           if (it != trackFeatures.featuresPerFrame.end())
             ++nbHighlightPointsToDraw; // to draw a highlight point in order to identify the current match
-
+          
           if (trackFeatures.nbLandmarks > 0)
             nbReprojectionErrorLinesToDraw += trackFeatures.featuresPerFrame.size(); // one line per matches for rerojection error
 
@@ -474,8 +475,9 @@ namespace qtAliceVision
           continue;
       }
 
-      const int state = globalTrackInfo.reconstructionState();
-      const bool trackHasInliers = (state != 0);
+      const MFeatures::ReconstructionState state = globalTrackInfo.reconstructionState();
+      const int stateIdx = static_cast<int>(state);
+      const bool trackHasInliers = (state != MFeatures::ReconstructionState::None);
 
       const MFeature* previousFeature = nullptr;
       aliceVision::IndexT previousFrameId = aliceVision::UndefinedIndexT;
@@ -510,7 +512,7 @@ namespace qtAliceVision
 
           // draw track line
           const QColor&  c = getLineColor(contiguous, inliers, trackHasInliers);
-          unsigned int vIdx = nbTrackLinesDrawn[state] * kLineVertices;
+          unsigned int vIdx = nbTrackLinesDrawn[stateIdx] * kLineVertices;
 
           QPointF prevPoint;
           QPointF curPoint;
@@ -525,10 +527,10 @@ namespace qtAliceVision
             curPoint = QPointF(feature->x(), feature->y());
           }
 
-          setVertex(verticesTrackLines[state], vIdx, prevPoint, c);
-          setVertex(verticesTrackLines[state], vIdx + 1, curPoint, c);
+          setVertex(verticesTrackLines[stateIdx], vIdx, prevPoint, c);
+          setVertex(verticesTrackLines[stateIdx], vIdx + 1, curPoint, c);
 
-          ++nbTrackLinesDrawn[state];
+          ++nbTrackLinesDrawn[stateIdx];
 
           previousTrackLineContiguous = contiguous;
 

--- a/src/FeaturesViewer.hpp
+++ b/src/FeaturesViewer.hpp
@@ -145,6 +145,9 @@ namespace qtAliceVision {
     QColor _featureColor = QColor(20, 220, 80);
     QColor _matchColor = QColor(255, 127, 0);
     QColor _landmarkColor = QColor(255, 0, 0);
+    QColor _trackReconstructionColors[3] = {
+      QColor(0,0,255), QColor(0,255,0), QColor(255,0,0)
+    };
 
     QString _describerType = "sift";
     MFeatures* _mfeatures = nullptr;

--- a/src/FeaturesViewer.hpp
+++ b/src/FeaturesViewer.hpp
@@ -40,6 +40,8 @@ namespace qtAliceVision {
       Q_PROPERTY(bool trackContiguousFilter MEMBER _trackContiguousFilter NOTIFY trackContiguousFilterChanged)
       // Display only tracks with at least one inlier
       Q_PROPERTY(bool trackInliersFilter MEMBER _trackInliersFilter NOTIFY trackInliersFilterChanged)
+      // Display track endpoints
+      Q_PROPERTY(bool displayTrackEndpoints MEMBER _displayTrackEndpoints NOTIFY displayTrackEndpointsChanged)
       // Features color
       Q_PROPERTY(QColor featureColor MEMBER _featureColor NOTIFY featureColorChanged)
       // Matches color
@@ -100,6 +102,7 @@ namespace qtAliceVision {
     Q_SIGNAL void display3dTracksChanged();
     Q_SIGNAL void trackContiguousFilterChanged();
     Q_SIGNAL void trackInliersFilterChanged();
+    Q_SIGNAL void displayTrackEndpointsChanged();
 
     Q_SIGNAL void featureColorChanged();
     Q_SIGNAL void matchColorChanged();
@@ -146,10 +149,12 @@ namespace qtAliceVision {
     bool _display3dTracks = false;
     bool _trackContiguousFilter = true;
     bool _trackInliersFilter = false;
+    bool _displayTrackEndpoints = true;
 
     QColor _featureColor = QColor(20, 220, 80);
     QColor _matchColor = QColor(255, 127, 0);
     QColor _landmarkColor = QColor(255, 0, 0);
+    QColor _endpointColor = QColor(80, 80, 80);
 
     QString _describerType = "sift";
     MFeatures* _mfeatures = nullptr;

--- a/src/FeaturesViewer.hpp
+++ b/src/FeaturesViewer.hpp
@@ -81,9 +81,9 @@ namespace qtAliceVision {
       float minFeatureScale = std::numeric_limits<float>::min();
       float maxFeatureScale = std::numeric_limits<float>::max();
 
-      std::size_t nbFeaturesToDraw = 0;
-      std::size_t nbMatchesToDraw = 0;
-      std::size_t nbLandmarksToDraw = 0;
+      int nbFeaturesToDraw = 0;
+      int nbMatchesToDraw = 0;
+      int nbLandmarksToDraw = 0;
     };
 
     /// Signals
@@ -133,7 +133,7 @@ namespace qtAliceVision {
 
     QSGGeometry* getCleanChildGeometry(QSGNode* node, int childIdx, int vertexCount, int indexCount = 0);
     QSGGeometry* appendChildGeometry(QSGNode* node, int vertexCount, int indexCount = 0);
-    void setVertex(QSGGeometry::ColoredPoint2D* vertices, unsigned int idx, const QPointF& point, const QColor& c);
+    void setVertex(QSGGeometry::ColoredPoint2D* vertices, int idx, const QPointF& point, const QColor& c);
 
     bool _displayFeatures = true;
     bool _displayTracks = true;

--- a/src/FeaturesViewer.hpp
+++ b/src/FeaturesViewer.hpp
@@ -5,6 +5,7 @@
 #include <MTracks.hpp>
 
 #include <QQuickItem>
+#include <QSGGeometry>
 
 namespace qtAliceVision {
 
@@ -120,12 +121,16 @@ namespace qtAliceVision {
     QSGNode* updatePaintNode(QSGNode* oldNode, QQuickItem::UpdatePaintNodeData* data) override;
 
   private:
-    void updatePaintFeatures(const PaintParams& params, QSGNode* oldNode, QSGNode* node);
-    void updatePaintTracks(const PaintParams& params, QSGNode* oldNode, QSGNode* node);
-    void updatePaintMatches(const PaintParams& params, QSGNode* oldNode, QSGNode* node);
-    void updatePaintLandmarks(const PaintParams& params, QSGNode* oldNode, QSGNode* node);
+    void updatePaintFeatures(const PaintParams& params, QSGNode* node);
+    void updatePaintTracks(const PaintParams& params, QSGNode* node);
+    void updatePaintMatches(const PaintParams& params, QSGNode* node);
+    void updatePaintLandmarks(const PaintParams& params, QSGNode* node);
 
     void initializePaintParams(PaintParams& params);
+
+    QSGGeometry* getCleanChildGeometry(QSGNode* node, int childIdx, int vertexCount, int indexCount = 0);
+    QSGGeometry* appendChildGeometry(QSGNode* node, int vertexCount, int indexCount = 0);
+    void setVertex(QSGGeometry::ColoredPoint2D* vertices, unsigned int idx, const QPointF& point, const QColor& c);
 
     bool _displayFeatures = true;
     bool _displayTracks = true;

--- a/src/FeaturesViewer.hpp
+++ b/src/FeaturesViewer.hpp
@@ -145,9 +145,6 @@ namespace qtAliceVision {
     QColor _featureColor = QColor(20, 220, 80);
     QColor _matchColor = QColor(255, 127, 0);
     QColor _landmarkColor = QColor(255, 0, 0);
-    QColor _trackReconstructionColors[3] = {
-      QColor(0,0,255), QColor(0,255,0), QColor(255,0,0)
-    };
 
     QString _describerType = "sift";
     MFeatures* _mfeatures = nullptr;

--- a/src/MFeatures.cpp
+++ b/src/MFeatures.cpp
@@ -201,7 +201,7 @@ void MFeatures::updateGlobalTrackInfo(MViewFeaturesPerViewPerDesc* viewFeaturesP
         const aliceVision::IndexT frameId = viewFeatures.frameId;
         for (auto* feature : viewFeatures.features)
         {
-        const int trackId = feature->trackId();
+        const aliceVision::IndexT trackId = static_cast<aliceVision::IndexT>(feature->trackId());
         MGlobalTrackInfo& info = _globalTrackInfoPerTrack[trackId];
 
         info.nbFeatures++;

--- a/src/MFeatures.hpp
+++ b/src/MFeatures.hpp
@@ -314,7 +314,7 @@ private:
     int _timeWindow = 1;            // size of the time window (from current frame - time window to current frame + time window), 0 is disable, -1 is no limit
 
     Status _localInfoStatus = MFeatures::None;
-    Status _globalInfoStatus = MFeatures::None;
+    Status _globalInfoStatus = MFeatures::Ready;
 
     // internal data
     std::map<QString, float> _minFeatureScalePerDesc;

--- a/src/MFeatures.hpp
+++ b/src/MFeatures.hpp
@@ -85,6 +85,7 @@ public:
       aliceVision::IndexT maxFrameId = std::numeric_limits<aliceVision::IndexT>::min();
       int nbLandmarks = 0;             // number of features of the track associated to a 3D landmark
       float featureScaleAverage = 0.f; // average feature scale
+      int reconstructionState = 0; // 0: not reconstructed, 1: partially reconstructed, 2: fully reconstructed
     };
     using MTrackFeaturesPerTrack = std::map<aliceVision::IndexT, MTrackFeatures>;
     using MTrackFeaturesPerTrackPerDesc = std::map<QString, MTrackFeaturesPerTrack>;

--- a/src/MFeatures.hpp
+++ b/src/MFeatures.hpp
@@ -85,7 +85,6 @@ public:
       aliceVision::IndexT maxFrameId = std::numeric_limits<aliceVision::IndexT>::min();
       int nbLandmarks = 0;             // number of features of the track associated to a 3D landmark
       float featureScaleAverage = 0.f; // average feature scale
-      int reconstructionState = 0; // 0: not reconstructed, 1: partially reconstructed, 2: fully reconstructed
     };
     using MTrackFeaturesPerTrack = std::map<aliceVision::IndexT, MTrackFeatures>;
     using MTrackFeaturesPerTrackPerDesc = std::map<QString, MTrackFeaturesPerTrack>;
@@ -94,6 +93,7 @@ public:
 
     Q_SLOT void load();
     Q_SLOT void clearAndLoad();
+    Q_SLOT void updateTrackReconstructionStates();
     Q_SLOT void onFeaturesReady(MViewFeaturesPerViewPerDesc* viewFeaturesPerViewPerDesc);
 
     /// Signals
@@ -219,9 +219,17 @@ public:
         Q_EMIT featuresChanged();
     }
 
+    int trackReconstructionState(aliceVision::IndexT trackId) 
+    {
+      return _trackReconstructionStates[trackId];
+    }
+
 private:
 
     /// Private methods (to use with Loading status)
+
+    // tmp
+    void getAllViewIds(std::vector<aliceVision::IndexT>& viewIds);
 
     /**
     * @brief Get the list of view ids to load in memory
@@ -235,13 +243,13 @@ private:
     * @brief Update MViewFeatures information with Tracks information
     * @return true if MViewFeatures information have been updated
     */
-    bool updateFromTracks();
+    bool updateFromTracks(MViewFeaturesPerViewPerDesc* viewFeaturesPerViewPerDesc);
 
     /**
     * @brief Update MViewFeatures information with SfMData information
     * @return true if MViewFeatures information have been updated
     */
-    bool updateFromSfM();
+    bool updateFromSfM(MViewFeaturesPerViewPerDesc* viewFeaturesPerViewPerDesc);
 
     /**
     * @brief Update min / max feature scale per describer
@@ -285,6 +293,8 @@ private:
     MViewFeaturesPerViewPerDesc _viewFeaturesPerViewPerDesc;
     MTrackFeaturesPerTrackPerDesc _trackFeaturesPerTrackPerDesc;
     QVariantMap _featuresInfo;
+
+    std::map<aliceVision::IndexT, int> _trackReconstructionStates;
 
     /// external data
     MSfMData* _msfmData = nullptr;

--- a/src/MFeatures.hpp
+++ b/src/MFeatures.hpp
@@ -299,6 +299,9 @@ private:
     void clearAllFeatureReprojection();
     void clearAll();
 
+    void setLocalInfoStatus(Status status);
+    void setGlobalInfoStatus(Status status);
+    
     /// Private members
 
     // inputs
@@ -310,8 +313,8 @@ private:
     bool _enableTimeWindow = false; // set to true if the user request multiple frames (e.g. display tracks)
     int _timeWindow = 1;            // size of the time window (from current frame - time window to current frame + time window), 0 is disable, -1 is no limit
 
-    bool _localInfoReady = false;
-    bool _globalInfoReady = false;
+    Status _localInfoStatus = MFeatures::None;
+    Status _globalInfoStatus = MFeatures::None;
 
     // internal data
     std::map<QString, float> _minFeatureScalePerDesc;

--- a/src/MFeatures.hpp
+++ b/src/MFeatures.hpp
@@ -286,6 +286,9 @@ private:
     bool _enableTimeWindow = false; // set to true if the user request multiple frames (e.g. display tracks)
     int _timeWindow = 1;            // size of the time window (from current frame - time window to current frame + time window), 0 is disable, -1 is no limit
 
+    bool _featuresReady = false;
+    bool _trackReconstructionStatesReady = false;
+
     // internal data
     std::map<QString, float> _minFeatureScalePerDesc;
     std::map<QString, float> _maxFeatureScalePerDesc;

--- a/src/MFeatures.hpp
+++ b/src/MFeatures.hpp
@@ -89,17 +89,23 @@ public:
     using MTrackFeaturesPerTrack = std::map<aliceVision::IndexT, MTrackFeatures>;
     using MTrackFeaturesPerTrackPerDesc = std::map<QString, MTrackFeaturesPerTrack>;
 
+    enum class ReconstructionState {
+        None = 0,
+        Partial = 1,
+        Complete = 2
+    };
+
     struct MGlobalTrackInfo {
       int nbFeatures = 0;
       int nbLandmarks = 0;
       aliceVision::IndexT startFrameId = std::numeric_limits<aliceVision::IndexT>::max();
       aliceVision::IndexT endFrameId = std::numeric_limits<aliceVision::IndexT>::min();
 
-      int reconstructionState() const 
+      ReconstructionState reconstructionState() const
       {
-        if (nbLandmarks == 0) return 0;
-        if (nbLandmarks < nbFeatures) return 1;
-        return 2;
+        if (nbLandmarks == 0) return ReconstructionState::None;
+        if (nbLandmarks < nbFeatures) return ReconstructionState::Partial;
+        return ReconstructionState::Complete;
       }
     };
     using MGlobalTrackInfoPerTrack = std::map<aliceVision::IndexT, MGlobalTrackInfo>;


### PR DESCRIPTION
## Description

This PR introduces new concepts in tracks visualization for conveying **global** information on them (i.e not limited to the current time window): 
- reconstruction states
- start/end points

### Reconstruction states

This PR introduces 3 *reconstruction states* for tracks: 
- 0: no feature on the track has been reconstructed
- 1: at least one feature on the track has been reconstructed
- 2: all features on the track have been reconstructed.

> Note: by *reconstructed* we mean that the feature has a corresponding 3D landmark

These states are visualized with the following visual code: 
- 0: thin lines with uniform discreet color
- 1: thin lines with non-uniform colors: landmark color (red) when both endpoints are reconstructed, otherwise match color (orange)
- 2: thick lines with uniform landmark color (red)

### Start/end point

The start/end points of a track (i.e the track features on the view with minimal/maximal frameId) are visualized with oriented triangles.
This visualization can be toggled on/off using a new QML property called `displayTrackEndpoints`.

## Implementation remarks

Since these concepts need global information on the tracks, it is necessary to load all the features from all the views in the scene, which makes the first loading of the FeaturesViewer longer.

## Important

This PR should be merged before https://github.com/alicevision/Meshroom/pull/1838