### PR TITLE
[depthMapEntity] Fix sim map loading

### DIFF
--- a/src/depthMapEntity/DepthMapEntity.hpp
+++ b/src/depthMapEntity/DepthMapEntity.hpp
@@ -81,6 +81,8 @@ public:
 private:
     Status _status = DepthMapEntity::None;
     QUrl _source;
+    QUrl _depthMapSource;
+    QUrl _simMapSource;
     DisplayMode _displayMode = DisplayMode::Triangles;
     bool _displayColor = true;
     float _pointSize = 0.5f;


### PR DESCRIPTION
## Description

The expected behaviour of the `DepthMapEntity` when setting its `source` property is that it will always display a point cloud with:
- positions corresponding to depth values 
- color corresponding to sim values if a sim map is found, depth values otherwise.

Previously, when a user would load a sim map, they would visualize a point cloud using sim values for color *and* position, which is not desired.
This PR fixes this issue by resolving the URLs of both maps when setting the source property.

## Tests

This PR has been tested on a photogrammetry pipeline with the outputs of both the `DepthMap` and `DepthMapFilter` nodes.