### PR TITLE
[build] Update compilation flags and fix all warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,12 @@ find_package(Qt5 COMPONENTS Charts REQUIRED)
 # Target properties
 add_library(qtAliceVisionPlugin SHARED ${PLUGIN_SOURCES} ${PLUGIN_HEADERS} ${PLUGIN_MOCS})
 
+if(MSVC)
+    target_compile_options(qtAliceVisionPlugin PUBLIC /W4)
+else()
+    target_compile_options(qtAliceVisionPlugin PUBLIC -Wall -Wextra -Wconversion -Wsign-conversion -Wshadow -Wpedantic)
+endif()
+
 target_link_libraries(qtAliceVisionPlugin
   PUBLIC
     aliceVision_feature

--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -146,8 +146,8 @@ namespace qtAliceVision
     {
       QColor c = _featureColor;
       vertices[index].set(
-        (float)point.x(), (float)point.y(),
-        (uchar)c.red(), (uchar)c.green(), (uchar)c.blue(), (uchar)c.alpha()
+        static_cast<float>(point.x()), static_cast<float>(point.y()),
+        static_cast<uchar>(c.red()), static_cast<uchar>(c.green()), static_cast<uchar>(c.blue()), static_cast<uchar>(c.alpha())
       );
     };
 
@@ -474,26 +474,26 @@ namespace qtAliceVision
       QColor c = QColor(200, 200, 200);
       if (alpha == 0)
         c = QColor(0, 0, 0, 0); // color should be rgba(0,0,0,0) in order to be transparent.
-      verticesHighlightPoints[index].set((float)point.x(), (float)point.y(), (uchar)c.red(), (uchar)c.green(), (uchar)c.blue(), (uchar)c.alpha());
+      verticesHighlightPoints[index].set(static_cast<float>(point.x()), static_cast<float>(point.y()), static_cast<uchar>(c.red()), static_cast<uchar>(c.green()), static_cast<uchar>(c.blue()), static_cast<uchar>(c.alpha()));
     };
 
     // utility lambda to register a track line vertex
     const auto setVerticeTrackLine = [&](unsigned int index, const QPointF& point, const QColor& c)
     {
-      verticesTrackLines[index].set((float)point.x(), (float)point.y(), (uchar)c.red(), (uchar)c.green(), (uchar)c.blue(), (uchar)c.alpha());
+      verticesTrackLines[index].set(static_cast<float>(point.x()), static_cast<float>(point.y()), static_cast<uchar>(c.red()), static_cast<uchar>(c.green()), static_cast<uchar>(c.blue()), static_cast<uchar>(c.alpha()));
     };
 
     // utility lambda to register a reprojection error line vertex
     const auto setVerticeReprojectionErrorLine = [&](unsigned int index, const QPointF& point, const QColor& c)
     {
       const QColor rc = c.darker(150); // darken the color to avoid confusion with track lines
-      verticesReprojectionErrorLines[index].set((float)point.x(), (float)point.y(), (uchar)rc.red(), (uchar)rc.green(), (uchar)rc.blue(), (uchar)rc.alpha());
+      verticesReprojectionErrorLines[index].set(static_cast<float>(point.x()), static_cast<float>(point.y()), static_cast<uchar>(rc.red()), static_cast<uchar>(rc.green()), static_cast<uchar>(rc.blue()), static_cast<uchar>(rc.alpha()));
     };
 
     // utility lambda to register a point vertex
     const auto setVerticePoint = [&](unsigned int index, const QPointF& point, const QColor& c)
     {
-      verticesPoints[index].set((float)point.x(), (float)point.y(), (uchar)c.red(), (uchar)c.green(), (uchar)c.blue(), (uchar)c.alpha());
+      verticesPoints[index].set(static_cast<float>(point.x()), static_cast<float>(point.y()), static_cast<uchar>(c.red()), static_cast<uchar>(c.green()), static_cast<uchar>(c.blue()), static_cast<uchar>(c.alpha()));
     };
 
     // utility lambda to register a feature point, to avoid code complexity
@@ -677,8 +677,8 @@ namespace qtAliceVision
     const auto setVerticePoint = [&](unsigned int index, const QPointF& point)
     {
       verticesPoints[index].set(
-        (float)point.x(), (float)point.y(),
-        (uchar)_matchColor.red(), (uchar)_matchColor.green(), (uchar)_matchColor.blue(), (uchar)_matchColor.alpha()
+        static_cast<float>(point.x()), static_cast<float>(point.y()),
+        static_cast<uchar>(_matchColor.red()), static_cast<uchar>(_matchColor.green()), static_cast<uchar>(_matchColor.blue()), static_cast<uchar>(_matchColor.alpha())
       );
     };
 
@@ -804,15 +804,15 @@ namespace qtAliceVision
     const auto setVerticeLine = [&](unsigned int index, const QPointF& point, const QColor& color)
     {
       verticesLines[index].set(
-        (float)point.x(), (float)point.y(),
-        (uchar)color.red(), (uchar)color.green(), (uchar)color.blue(), (uchar)color.alpha()
+        static_cast<float>(point.x()), static_cast<float>(point.y()),
+        static_cast<uchar>(color.red()), static_cast<uchar>(color.green()), static_cast<uchar>(color.blue()), static_cast<uchar>(color.alpha())
       );
     };
     const auto setVerticePoint = [&](unsigned int index, const QPointF& point, const QColor& color)
     {
       verticesPoints[index].set(
-        (float)point.x(), (float)point.y(),
-        (uchar)color.red(), (uchar)color.green(), (uchar)color.blue(), (uchar)color.alpha()
+        static_cast<float>(point.x()), static_cast<float>(point.y()),
+        static_cast<uchar>(color.red()), static_cast<uchar>(color.green()), static_cast<uchar>(color.blue()), static_cast<uchar>(color.alpha())
       );
     };
 

--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -151,7 +151,8 @@ namespace qtAliceVision
       QColor c = _featureColor;
       vertices[index].set(
         static_cast<float>(point.x()), static_cast<float>(point.y()),
-        static_cast<uchar>(c.red()), static_cast<uchar>(c.green()), static_cast<uchar>(c.blue()), static_cast<uchar>(c.alpha())
+        static_cast<uchar>(c.red()), static_cast<uchar>(c.green()), static_cast<uchar>(c.blue()),
+        static_cast<uchar>(c.alpha())
       );
     };
 
@@ -173,7 +174,8 @@ namespace qtAliceVision
 
       if (nbFeaturesDrawn >= params.nbFeaturesToDraw)
       {
-        qWarning() << "[QtAliceVision] FeaturesViewer: Update paint " << _describerType << " features, Error on number of features.";
+        qWarning() << "[QtAliceVision] FeaturesViewer: Update paint " << _describerType
+                   << " features, Error on number of features.";
         break;
       }
 
@@ -242,8 +244,11 @@ namespace qtAliceVision
 
     const unsigned int kLineVertices = 2;
 
-    const MFeatures::MTrackFeaturesPerTrack* trackFeaturesPerTrack = (_displayTracks && params.haveValidFeatures && params.haveValidTracks && params.haveValidLandmarks) ? _mfeatures->getTrackFeaturesPerTrack(_describerType) : nullptr;
-    const aliceVision::IndexT currentFrameId = (trackFeaturesPerTrack != nullptr) ? _mfeatures->getCurrentFrameId() : aliceVision::UndefinedIndexT;
+    const MFeatures::MTrackFeaturesPerTrack* trackFeaturesPerTrack =
+        (_displayTracks && params.haveValidFeatures && params.haveValidTracks && params.haveValidLandmarks)
+        ? _mfeatures->getTrackFeaturesPerTrack(_describerType) : nullptr;
+    const aliceVision::IndexT currentFrameId = (trackFeaturesPerTrack != nullptr)
+        ? _mfeatures->getCurrentFrameId() : aliceVision::UndefinedIndexT;
 
     std::size_t nbTracksToDraw = 0;
     std::size_t nbTrackLinesToDraw = 0;
@@ -478,26 +483,42 @@ namespace qtAliceVision
       QColor c = QColor(200, 200, 200);
       if (alpha == 0)
         c = QColor(0, 0, 0, 0); // color should be rgba(0,0,0,0) in order to be transparent.
-      verticesHighlightPoints[index].set(static_cast<float>(point.x()), static_cast<float>(point.y()), static_cast<uchar>(c.red()), static_cast<uchar>(c.green()), static_cast<uchar>(c.blue()), static_cast<uchar>(c.alpha()));
+      verticesHighlightPoints[index].set(
+        static_cast<float>(point.x()), static_cast<float>(point.y()),
+        static_cast<uchar>(c.red()), static_cast<uchar>(c.green()), static_cast<uchar>(c.blue()),
+        static_cast<uchar>(c.alpha())
+      );
     };
 
     // utility lambda to register a track line vertex
     const auto setVerticeTrackLine = [&](unsigned int index, const QPointF& point, const QColor& c)
     {
-      verticesTrackLines[index].set(static_cast<float>(point.x()), static_cast<float>(point.y()), static_cast<uchar>(c.red()), static_cast<uchar>(c.green()), static_cast<uchar>(c.blue()), static_cast<uchar>(c.alpha()));
+      verticesTrackLines[index].set(
+        static_cast<float>(point.x()), static_cast<float>(point.y()),
+        static_cast<uchar>(c.red()), static_cast<uchar>(c.green()), static_cast<uchar>(c.blue()),
+        static_cast<uchar>(c.alpha())
+      );
     };
 
     // utility lambda to register a reprojection error line vertex
     const auto setVerticeReprojectionErrorLine = [&](unsigned int index, const QPointF& point, const QColor& c)
     {
       const QColor rc = c.darker(150); // darken the color to avoid confusion with track lines
-      verticesReprojectionErrorLines[index].set(static_cast<float>(point.x()), static_cast<float>(point.y()), static_cast<uchar>(rc.red()), static_cast<uchar>(rc.green()), static_cast<uchar>(rc.blue()), static_cast<uchar>(rc.alpha()));
+      verticesReprojectionErrorLines[index].set(
+        static_cast<float>(point.x()), static_cast<float>(point.y()),
+        static_cast<uchar>(rc.red()), static_cast<uchar>(rc.green()), static_cast<uchar>(rc.blue()),
+        static_cast<uchar>(rc.alpha())
+      );
     };
 
     // utility lambda to register a point vertex
     const auto setVerticePoint = [&](unsigned int index, const QPointF& point, const QColor& c)
     {
-      verticesPoints[index].set(static_cast<float>(point.x()), static_cast<float>(point.y()), static_cast<uchar>(c.red()), static_cast<uchar>(c.green()), static_cast<uchar>(c.blue()), static_cast<uchar>(c.alpha()));
+      verticesPoints[index].set(
+        static_cast<float>(point.x()), static_cast<float>(point.y()),
+        static_cast<uchar>(c.red()), static_cast<uchar>(c.green()), static_cast<uchar>(c.blue()),
+        static_cast<uchar>(c.alpha())
+      );
     };
 
     // utility lambda to register a feature point, to avoid code complexity
@@ -521,7 +542,8 @@ namespace qtAliceVision
         // draw a highlight point in order to identify the current match from the others
         if (frameId == curFrameId)
         {
-          setVerticeHighlightPoint(nbHighlightPointsDrawn, (_display3dTracks && trackHasInliers) ? point3d : point2d, color.alpha());
+          setVerticeHighlightPoint(nbHighlightPointsDrawn,
+                                   (_display3dTracks && trackHasInliers) ? point3d : point2d, color.alpha());
           ++nbHighlightPointsDrawn;
         }
 
@@ -541,7 +563,8 @@ namespace qtAliceVision
 
     if (currentFrameId == aliceVision::UndefinedIndexT)
     {
-      qInfo() << "[QtAliceVision] FeaturesViewer: Unable to update paint " << _describerType << " tracks, can't find current frame id.";
+      qInfo() << "[QtAliceVision] FeaturesViewer: Unable to update paint "
+              << _describerType << " tracks, can't find current frame id.";
       return;
     }
 
@@ -594,12 +617,16 @@ namespace qtAliceVision
 
 
           // draw previous point
-          const QColor& previousPointColor = getColor(false, contiguous || previousTrackLineContiguous, previousFeatureInlier, trackHasInliers);
-          drawFeaturePoint(currentFrameId, previousFrameId, previousFeature, previousPointColor, nbReprojectionErrorLinesDrawn, nbHighlightPointsDrawn, nbPointsDrawn, trackHasInliers);
+          const QColor& previousPointColor = getColor(false, contiguous || previousTrackLineContiguous,
+            previousFeatureInlier, trackHasInliers);
+          drawFeaturePoint(currentFrameId, previousFrameId, previousFeature, previousPointColor,
+            nbReprojectionErrorLinesDrawn, nbHighlightPointsDrawn, nbPointsDrawn, trackHasInliers);
 
           // draw track last point
           if (frameId == trackFeatures.maxFrameId)
-            drawFeaturePoint(currentFrameId, frameId, feature, getColor(false, contiguous, currentFeatureInlier, trackHasInliers), nbReprojectionErrorLinesDrawn, nbHighlightPointsDrawn, nbPointsDrawn, trackHasInliers);
+            drawFeaturePoint(currentFrameId, frameId, feature,
+              getColor(false, contiguous, currentFeatureInlier, trackHasInliers),
+              nbReprojectionErrorLinesDrawn, nbHighlightPointsDrawn, nbPointsDrawn, trackHasInliers);
 
           // draw track line
           const QColor&  c = getColor(true, contiguous, inliers, trackHasInliers);
@@ -707,7 +734,8 @@ namespace qtAliceVision
 
         if (nbMatchesDrawn >= params.nbMatchesToDraw)
         {
-          qWarning() << "[QtAliceVision] FeaturesViewer: Update paint " << _describerType << " matches, Error on number of matches.";
+          qWarning() << "[QtAliceVision] FeaturesViewer: Update paint "
+                     << _describerType << " matches, Error on number of matches.";
           break;
         }
 
@@ -809,14 +837,16 @@ namespace qtAliceVision
     {
       verticesLines[index].set(
         static_cast<float>(point.x()), static_cast<float>(point.y()),
-        static_cast<uchar>(color.red()), static_cast<uchar>(color.green()), static_cast<uchar>(color.blue()), static_cast<uchar>(color.alpha())
+        static_cast<uchar>(color.red()), static_cast<uchar>(color.green()), static_cast<uchar>(color.blue()),
+        static_cast<uchar>(color.alpha())
       );
     };
     const auto setVerticePoint = [&](unsigned int index, const QPointF& point, const QColor& color)
     {
       verticesPoints[index].set(
         static_cast<float>(point.x()), static_cast<float>(point.y()),
-        static_cast<uchar>(color.red()), static_cast<uchar>(color.green()), static_cast<uchar>(color.blue()), static_cast<uchar>(color.alpha())
+        static_cast<uchar>(color.red()), static_cast<uchar>(color.green()), static_cast<uchar>(color.blue()),
+        static_cast<uchar>(color.alpha())
       );
     };
 
@@ -842,7 +872,8 @@ namespace qtAliceVision
 
         if (nbLandmarksDrawn >= params.nbLandmarksToDraw)
         {
-          qWarning() << "[QtAliceVision] FeaturesViewer: Update paint " << _describerType << " landmarks, Error on number of landmarks.";
+          qWarning() << "[QtAliceVision] FeaturesViewer: Update paint "
+                     << _describerType << " landmarks, Error on number of landmarks.";
           break;
         }
 

--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -272,7 +272,7 @@ namespace qtAliceVision
 
         ++nbTracksToDraw;
         nbTrackLinesToDraw += (trackFeatures.featuresPerFrame.size() - 1); // number of lines in the track
-        
+
         if (_trackDisplayMode == WithCurrentMatches)
         {
           const auto it = trackFeatures.featuresPerFrame.find(currentFrameId);
@@ -289,7 +289,7 @@ namespace qtAliceVision
           const auto it = trackFeatures.featuresPerFrame.find(currentFrameId);
           if (it != trackFeatures.featuresPerFrame.end())
             ++nbHighlightPointsToDraw; // to draw a highlight point in order to identify the current match
-          
+
           if (trackFeatures.nbLandmarks > 0)
             nbReprojectionErrorLinesToDraw += trackFeatures.featuresPerFrame.size(); // one line per matches for rerojection error
 
@@ -408,7 +408,7 @@ namespace qtAliceVision
 
       if (!rootHighlightPoint || !rootTrackLine || !rootReprojectionErrorLine || !rootPoint)
         return;
-      
+
       rootHighlightPoint->markDirty(QSGNode::DirtyGeometry);
       rootTrackLine->markDirty(QSGNode::DirtyGeometry);
       rootReprojectionErrorLine->markDirty(QSGNode::DirtyGeometry);
@@ -502,11 +502,11 @@ namespace qtAliceVision
 
     // utility lambda to register a feature point, to avoid code complexity
     const auto drawFeaturePoint = [&](aliceVision::IndexT curFrameId,
-                                      aliceVision::IndexT frameId, 
-                                      const MFeature* feature, 
+                                      aliceVision::IndexT frameId,
+                                      const MFeature* feature,
                                       const QColor& color,
-                                      unsigned int& nbReprojectionErrorLinesDrawn, 
-                                      unsigned int& nbHighlightPointsDrawn, 
+                                      unsigned int& nbReprojectionErrorLinesDrawn,
+                                      unsigned int& nbHighlightPointsDrawn,
                                       unsigned int& nbPointsDrawn,
                                       bool trackHasInliers)
     {
@@ -514,7 +514,7 @@ namespace qtAliceVision
       {
         const QPointF point2d = QPointF(feature->x(), feature->y());
         const QPointF point3d = QPointF(feature->rx(), feature->ry());
-       
+
         setVerticePoint(nbPointsDrawn, trackHasInliers ? point3d : point2d, color);
         ++nbPointsDrawn;
 
@@ -687,7 +687,7 @@ namespace qtAliceVision
     };
 
     if (params.nbMatchesToDraw == 0) // nothing to draw or something is not ready
-      return; 
+      return;
 
     unsigned int nbMatchesDrawn = 0;
 
@@ -827,7 +827,7 @@ namespace qtAliceVision
 
     const MFeatures::MViewFeatures* currentViewFeatures = _mfeatures->getCurrentViewFeatures(_describerType);
     const QColor reprojectionColor = _landmarkColor.darker(150);
-    
+
     // Draw lines between reprojected points and features extracted
     for (const auto& feature : currentViewFeatures->features)
     {
@@ -870,7 +870,7 @@ namespace qtAliceVision
 
     const float minFeatureScale = _mfeatures->getMinFeatureScale(_describerType);
     const float difFeatureScale = _mfeatures->getMaxFeatureScale(_describerType) - minFeatureScale;
-    
+
     params.minFeatureScale = minFeatureScale + std::max(0.f, std::min(1.f, _featureMinScaleFilter)) * difFeatureScale;
     params.maxFeatureScale = minFeatureScale + std::max(0.f, std::min(1.f, _featureMaxScaleFilter)) * difFeatureScale;
 

--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -84,6 +84,8 @@ namespace qtAliceVision
     case FeaturesViewer::OrientedSquares:
       kFeatVertices = (4 * 2) + 2;  // doubled rectangle points + orientation line
       break;
+    default:
+      break;
     }
 
     if (!oldNode || oldNode->childCount() == 0)
@@ -135,6 +137,8 @@ namespace qtAliceVision
     case FeaturesViewer::OrientedSquares:
       geometry->setDrawingMode(QSGGeometry::DrawLines);
       geometry->setLineWidth(1.0f);
+      break;
+    default:
       break;
     }
 

--- a/src/FeaturesViewer.cpp
+++ b/src/FeaturesViewer.cpp
@@ -146,8 +146,8 @@ namespace qtAliceVision
     {
       QColor c = _featureColor;
       vertices[index].set(
-        point.x(), point.y(),
-        c.red(), c.green(), c.blue(), c.alpha()
+        (float)point.x(), (float)point.y(),
+        (uchar)c.red(), (uchar)c.green(), (uchar)c.blue(), (uchar)c.alpha()
       );
     };
 
@@ -474,30 +474,30 @@ namespace qtAliceVision
       QColor c = QColor(200, 200, 200);
       if (alpha == 0)
         c = QColor(0, 0, 0, 0); // color should be rgba(0,0,0,0) in order to be transparent.
-      verticesHighlightPoints[index].set(point.x(), point.y(), c.red(), c.green(), c.blue(), c.alpha());
+      verticesHighlightPoints[index].set((float)point.x(), (float)point.y(), (uchar)c.red(), (uchar)c.green(), (uchar)c.blue(), (uchar)c.alpha());
     };
 
     // utility lambda to register a track line vertex
     const auto setVerticeTrackLine = [&](unsigned int index, const QPointF& point, const QColor& c)
     {
-      verticesTrackLines[index].set(point.x(), point.y(), c.red(), c.green(), c.blue(), c.alpha());
+      verticesTrackLines[index].set((float)point.x(), (float)point.y(), (uchar)c.red(), (uchar)c.green(), (uchar)c.blue(), (uchar)c.alpha());
     };
 
     // utility lambda to register a reprojection error line vertex
     const auto setVerticeReprojectionErrorLine = [&](unsigned int index, const QPointF& point, const QColor& c)
     {
       const QColor rc = c.darker(150); // darken the color to avoid confusion with track lines
-      verticesReprojectionErrorLines[index].set(point.x(), point.y(), rc.red(), rc.green(), rc.blue(), rc.alpha());
+      verticesReprojectionErrorLines[index].set((float)point.x(), (float)point.y(), (uchar)rc.red(), (uchar)rc.green(), (uchar)rc.blue(), (uchar)rc.alpha());
     };
 
     // utility lambda to register a point vertex
     const auto setVerticePoint = [&](unsigned int index, const QPointF& point, const QColor& c)
     {
-      verticesPoints[index].set(point.x(), point.y(), c.red(), c.green(), c.blue(), c.alpha());
+      verticesPoints[index].set((float)point.x(), (float)point.y(), (uchar)c.red(), (uchar)c.green(), (uchar)c.blue(), (uchar)c.alpha());
     };
 
     // utility lambda to register a feature point, to avoid code complexity
-    const auto drawFeaturePoint = [&](aliceVision::IndexT currentFrameId, 
+    const auto drawFeaturePoint = [&](aliceVision::IndexT curFrameId,
                                       aliceVision::IndexT frameId, 
                                       const MFeature* feature, 
                                       const QColor& color,
@@ -506,7 +506,7 @@ namespace qtAliceVision
                                       unsigned int& nbPointsDrawn,
                                       bool trackHasInliers)
     {
-      if (_trackDisplayMode == WithAllMatches || (frameId == currentFrameId && _trackDisplayMode == WithCurrentMatches))
+      if (_trackDisplayMode == WithAllMatches || (frameId == curFrameId && _trackDisplayMode == WithCurrentMatches))
       {
         const QPointF point2d = QPointF(feature->x(), feature->y());
         const QPointF point3d = QPointF(feature->rx(), feature->ry());
@@ -515,7 +515,7 @@ namespace qtAliceVision
         ++nbPointsDrawn;
 
         // draw a highlight point in order to identify the current match from the others
-        if (frameId == currentFrameId) 
+        if (frameId == curFrameId)
         {
           setVerticeHighlightPoint(nbHighlightPointsDrawn, (_display3dTracks && trackHasInliers) ? point3d : point2d, color.alpha());
           ++nbHighlightPointsDrawn;
@@ -677,8 +677,8 @@ namespace qtAliceVision
     const auto setVerticePoint = [&](unsigned int index, const QPointF& point)
     {
       verticesPoints[index].set(
-        point.x(), point.y(),
-        _matchColor.red(), _matchColor.green(), _matchColor.blue(), _matchColor.alpha()
+        (float)point.x(), (float)point.y(),
+        (uchar)_matchColor.red(), (uchar)_matchColor.green(), (uchar)_matchColor.blue(), (uchar)_matchColor.alpha()
       );
     };
 
@@ -746,7 +746,7 @@ namespace qtAliceVision
         node->appendChildNode(root);
       }
       {
-        auto root = new QSGGeometryNode;
+        root = new QSGGeometryNode;
         // use VertexColorMaterial to later be able to draw selection in another color
         auto material = new QSGVertexColorMaterial;
         {
@@ -804,15 +804,15 @@ namespace qtAliceVision
     const auto setVerticeLine = [&](unsigned int index, const QPointF& point, const QColor& color)
     {
       verticesLines[index].set(
-        point.x(), point.y(),
-        color.red(), color.green(), color.blue(), color.alpha()
+        (float)point.x(), (float)point.y(),
+        (uchar)color.red(), (uchar)color.green(), (uchar)color.blue(), (uchar)color.alpha()
       );
     };
     const auto setVerticePoint = [&](unsigned int index, const QPointF& point, const QColor& color)
     {
       verticesPoints[index].set(
-        point.x(), point.y(),
-        color.red(), color.green(), color.blue(), color.alpha()
+        (float)point.x(), (float)point.y(),
+        (uchar)color.red(), (uchar)color.green(), (uchar)color.blue(), (uchar)color.alpha()
       );
     };
 
@@ -904,6 +904,7 @@ namespace qtAliceVision
 
   QSGNode* FeaturesViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdatePaintNodeData* data)
   {
+    (void)data; // Fix "unused parameter" warnings; should be replaced by [[maybe_unused]] when C++17 is supported
     PaintParams params;
     initializePaintParams(params);
 

--- a/src/FeaturesViewer.hpp
+++ b/src/FeaturesViewer.hpp
@@ -54,7 +54,6 @@ namespace qtAliceVision {
       Q_PROPERTY(qtAliceVision::MFeatures* mfeatures READ getMFeatures WRITE setMFeatures NOTIFY featuresChanged)
 
   public:
-
     /// Helpers
 
     enum FeatureDisplayMode {
@@ -72,7 +71,6 @@ namespace qtAliceVision {
     Q_ENUM(TrackDisplayMode)
 
     struct PaintParams {
-
       bool haveValidFeatures = false;
       bool haveValidTracks = false;
       bool haveValidLandmarks = false;
@@ -139,7 +137,7 @@ namespace qtAliceVision {
 
     float _featureMinScaleFilter = 0.f;
     float _featureMaxScaleFilter = 1.f;
-    
+
     bool _display3dTracks = false;
     bool _trackContiguousFilter = true;
     bool _trackInliersFilter = false;

--- a/src/FloatImageViewer.cpp
+++ b/src/FloatImageViewer.cpp
@@ -321,11 +321,11 @@ QSGNode* FloatImageViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdateP
                 const double radiusInPercentage = (fisheyeCircleParams.z() / ((width > height) ? height : width)) * 2.0;
 
                 //Radius is converted in uv coordinates (0, 0.5)
-                const float radius = 0.5f * (float)radiusInPercentage;
+                const float radius = 0.5f * static_cast<float>(radiusInPercentage);
 
-                material->state()->fisheyeCircleCoord = QVector2D((float)(fisheyeCircleParams.x() / width), (float)(fisheyeCircleParams.y() / height));
+                material->state()->fisheyeCircleCoord = QVector2D(static_cast<float>(fisheyeCircleParams.x() / width), static_cast<float>(fisheyeCircleParams.y() / height));
                 material->state()->fisheyeCircleRadius = radius;
-                material->state()->aspectRatio = (float)aspectRatio;
+                material->state()->aspectRatio = static_cast<float>(aspectRatio);
             }
             else
             {
@@ -350,7 +350,7 @@ QSGNode* FloatImageViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdateP
         _boundingRect = newBoundingRect;
 
         const double windowRatio = _boundingRect.width() / _boundingRect.height();
-        const float textureRatio = (float)_textureSize.width() / (float)_textureSize.height();
+        const float textureRatio = static_cast<float>(_textureSize.width()) / static_cast<float>(_textureSize.height());
         QRectF geometryRect = _boundingRect;
         if (windowRatio > textureRatio)
         {

--- a/src/FloatImageViewer.cpp
+++ b/src/FloatImageViewer.cpp
@@ -210,7 +210,8 @@ QSGNode* FloatImageViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdateP
     if (!root)
     {
         root = new QSGGeometryNode;
-        auto geometry = new QSGGeometry(QSGGeometry::defaultAttributes_TexturedPoint2D(), _surface.vertexCount(), _surface.indexCount());
+        auto geometry = new QSGGeometry(QSGGeometry::defaultAttributes_TexturedPoint2D(),
+                                        _surface.vertexCount(), _surface.indexCount());
         geometry->setDrawingMode(GL_TRIANGLES);
         geometry->setIndexDataPattern(QSGGeometry::StaticPattern);
         geometry->setVertexDataPattern(QSGGeometry::StaticPattern);
@@ -312,7 +313,10 @@ QSGNode* FloatImageViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdateP
             const aliceVision::camera::EquiDistant* intrinsicEquiDistant = _surface.getIntrinsicEquiDistant();
             if(_cropFisheye && intrinsicEquiDistant)
             {
-                const aliceVision::Vec3 fisheyeCircleParams(intrinsicEquiDistant->getCircleCenterX(), intrinsicEquiDistant->getCircleCenterY(), intrinsicEquiDistant->getCircleRadius());
+                const aliceVision::Vec3 fisheyeCircleParams(
+                    intrinsicEquiDistant->getCircleCenterX(),
+                    intrinsicEquiDistant->getCircleCenterY(),
+                    intrinsicEquiDistant->getCircleRadius());
 
                 const double width = _image->Width() * pow(2.0, _downscaleLevel);
                 const double height = _image->Height() * pow(2.0, _downscaleLevel);
@@ -323,7 +327,9 @@ QSGNode* FloatImageViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdateP
                 //Radius is converted in uv coordinates (0, 0.5)
                 const float radius = 0.5f * static_cast<float>(radiusInPercentage);
 
-                material->state()->fisheyeCircleCoord = QVector2D(static_cast<float>(fisheyeCircleParams.x() / width), static_cast<float>(fisheyeCircleParams.y() / height));
+                material->state()->fisheyeCircleCoord = QVector2D(
+                    static_cast<float>(fisheyeCircleParams.x() / width),
+                    static_cast<float>(fisheyeCircleParams.y() / height));
                 material->state()->fisheyeCircleRadius = radius;
                 material->state()->aspectRatio = static_cast<float>(aspectRatio);
             }

--- a/src/FloatImageViewer.cpp
+++ b/src/FloatImageViewer.cpp
@@ -81,20 +81,20 @@ FloatImageViewer::FloatImageViewer(QQuickItem* parent)
     // CONNECTS
     connect(this, &FloatImageViewer::gammaChanged, this, &FloatImageViewer::update);
     connect(this, &FloatImageViewer::gainChanged, this, &FloatImageViewer::update);
-    
+
     connect(this, &FloatImageViewer::textureSizeChanged, this, &FloatImageViewer::update);
     connect(this, &FloatImageViewer::sourceSizeChanged, this, &FloatImageViewer::update);
     connect(this, &FloatImageViewer::imageChanged, this, &FloatImageViewer::update);
     connect(this, &FloatImageViewer::sourceChanged, this, &FloatImageViewer::reload);
-    
+
     connect(this, &FloatImageViewer::channelModeChanged, this, &FloatImageViewer::update);
- 
+
     connect(this, &FloatImageViewer::downscaleLevelChanged, this, &FloatImageViewer::reload);
 
     connect(&_surface, &Surface::gridColorChanged, this, &FloatImageViewer::update);
     connect(&_surface, &Surface::gridOpacityChanged, this, &FloatImageViewer::update);
     connect(&_surface, &Surface::displayGridChanged, this, &FloatImageViewer::update);
-   
+
     connect(&_surface, &Surface::mouseOverChanged, this, &FloatImageViewer::update);
     connect(&_surface, &Surface::viewerTypeChanged, this, &FloatImageViewer::update);
 
@@ -391,7 +391,7 @@ void FloatImageViewer::updatePaintSurface(QSGGeometryNode* root, QSGSimpleMateri
         root->markDirty(QSGNode::DirtyMaterial);
     }
 
-    // If vertices has changed, Re-Compute the grid 
+    // If vertices has changed, Re-Compute the grid
     if (_surface.hasVerticesChanged())
     {
         // Retrieve Vertices and Index Data

--- a/src/FloatImageViewer.hpp
+++ b/src/FloatImageViewer.hpp
@@ -29,7 +29,6 @@ class FloatImageIORunnable : public QObject, public QRunnable
     Q_OBJECT
 
 public:
-
     explicit FloatImageIORunnable(const QUrl& path, int downscaleLevel = 0, QObject* parent = nullptr);
 
     /// Load image at path
@@ -48,7 +47,7 @@ private:
     */
 class FloatImageViewer : public QQuickItem
 {
-    
+
 Q_OBJECT
     // Q_PROPERTIES
     Q_PROPERTY(QUrl source MEMBER _source NOTIFY sourceChanged)
@@ -62,17 +61,17 @@ Q_OBJECT
     Q_PROPERTY(QSize textureSize MEMBER _textureSize NOTIFY textureSizeChanged)
 
     Q_PROPERTY(QSize sourceSize READ sourceSize NOTIFY sourceSizeChanged)
-    
+
     Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
 
     Q_PROPERTY(bool clearBeforeLoad MEMBER _clearBeforeLoad NOTIFY clearBeforeLoadChanged)
-    
+
     Q_PROPERTY(EChannelMode channelMode MEMBER _channelMode NOTIFY channelModeChanged)
-    
+
     Q_PROPERTY(QVariantMap metadata READ metadata NOTIFY metadataChanged)
-   
+
     Q_PROPERTY(int downscaleLevel READ getDownscaleLevel WRITE setDownscaleLevel NOTIFY downscaleLevelChanged)
-    
+
     Q_PROPERTY(Surface* surface READ getSurfacePtr NOTIFY surfaceChanged)
 
     Q_PROPERTY(bool cropFisheye READ getCropFisheye WRITE setCropFisheye NOTIFY isCropFisheyeChanged)
@@ -139,7 +138,7 @@ public:
 
     // Q_INVOKABLE
     Q_INVOKABLE QVector4D pixelValueAt(int x, int y);
-    
+
     Surface* getSurfacePtr() { return &_surface; }
 
 private:

--- a/src/FloatImageViewer.hpp
+++ b/src/FloatImageViewer.hpp
@@ -182,5 +182,5 @@ private:
 
 }
 
-Q_DECLARE_METATYPE(qtAliceVision::FloatImage);
-Q_DECLARE_METATYPE(QSharedPointer<qtAliceVision::FloatImage>);
+Q_DECLARE_METATYPE(qtAliceVision::FloatImage)
+Q_DECLARE_METATYPE(QSharedPointer<qtAliceVision::FloatImage>)

--- a/src/FloatTexture.cpp
+++ b/src/FloatTexture.cpp
@@ -48,10 +48,10 @@ int FloatTexture::textureId() const
         else if(_textureId == 0)
         {
             QOpenGLContext::currentContext()->functions()->glGenTextures(1, &const_cast<FloatTexture *>(this)->_textureId);
-            return (int)_textureId;
+            return static_cast<int>(_textureId);
         }
     }
-    return (int)_textureId;
+    return static_cast<int>(_textureId);
 }
 
 void FloatTexture::bind()

--- a/src/FloatTexture.cpp
+++ b/src/FloatTexture.cpp
@@ -30,7 +30,7 @@ void FloatTexture::setImage(QSharedPointer<FloatImage>& image)
     _dirty = true;
     _dirtyBindOptions = true;
     _mipmapsGenerated = false;
- }
+}
 
 bool FloatTexture::isValid() const
 {

--- a/src/FloatTexture.cpp
+++ b/src/FloatTexture.cpp
@@ -48,10 +48,10 @@ int FloatTexture::textureId() const
         else if(_textureId == 0)
         {
             QOpenGLContext::currentContext()->functions()->glGenTextures(1, &const_cast<FloatTexture *>(this)->_textureId);
-            return _textureId;
+            return (int)_textureId;
         }
     }
-    return _textureId;
+    return (int)_textureId;
 }
 
 void FloatTexture::bind()

--- a/src/FloatTexture.hpp
+++ b/src/FloatTexture.hpp
@@ -57,7 +57,7 @@ private:
 private:
     QSharedPointer<FloatImage> _srcImage;
 
-    uint _textureId = 0;
+    unsigned int _textureId = 0;
     QSize _textureSize;
 
     bool _dirty = false;

--- a/src/MFeature.cpp
+++ b/src/MFeature.cpp
@@ -33,7 +33,8 @@ void FeatureIORunnable::run()
     QList<MFeature*> feats;
     try
     {
-        std::unique_ptr<feature::ImageDescriber> describer = feature::createImageDescriber(feature::EImageDescriberType_stringToEnum(descType.toStdString()));
+        std::unique_ptr<feature::ImageDescriber> describer =
+            feature::createImageDescriber(feature::EImageDescriberType_stringToEnum(descType.toStdString()));
         regions = sfm::loadFeatures({folder.toLocalFile().toStdString()}, viewId, *describer);
     }
     catch(std::exception& e)

--- a/src/MFeature.cpp
+++ b/src/MFeature.cpp
@@ -38,8 +38,8 @@ void FeatureIORunnable::run()
     }
     catch(std::exception& e)
     {
-        qDebug() << "[QtAliceVision] Failed to load features (" << descType << ") for view: " << viewId << " from folder: " << folder
-                 << "\n" << e.what();
+        qDebug() << "[QtAliceVision] Failed to load features (" << descType << ") for view: " << viewId
+                 << " from folder: " << folder << "\n" << e.what();
 
         Q_EMIT resultReady(feats);
         return;

--- a/src/MFeature.hpp
+++ b/src/MFeature.hpp
@@ -27,7 +27,7 @@ class MFeature : public QObject
 
 public:
     MFeature() = default;
-    MFeature(const MFeature& other) { _feat = other._feat; }
+    MFeature(const MFeature& other) : QObject() { _feat = other._feat; }
 
     explicit MFeature(const aliceVision::feature::PointFeature& feat, QObject* parent=nullptr):
     QObject(parent)

--- a/src/MFeatures.cpp
+++ b/src/MFeatures.cpp
@@ -71,11 +71,13 @@ void FeaturesIORunnable::run()
 
     for (int dIdx = 0; dIdx < descTypes.size(); ++dIdx)
     {
-      std::vector<std::unique_ptr<aliceVision::feature::Regions>>& regionsPerView = regionsPerViewPerDesc.at(static_cast<uint>(dIdx));
+      std::vector<std::unique_ptr<aliceVision::feature::Regions>>& regionsPerView =
+        regionsPerViewPerDesc.at(static_cast<uint>(dIdx));
 
       for (std::size_t vIdx = 0; vIdx < viewIds.size(); ++vIdx)
       {
-        qDebug() << "[QtAliceVision] Features: Load " << descTypes.at(dIdx).toString() << " from viewId: " << viewIds.at(vIdx) << ".";
+        qDebug() << "[QtAliceVision] Features: Load " << descTypes.at(dIdx).toString()
+                 << " from viewId: " << viewIds.at(vIdx) << ".";
 
         MFeatures::MViewFeatures& viewFeatures = (*viewFeaturesPerViewPerDescPtr)[descTypes.at(dIdx).toString()][viewIds.at(vIdx)];
         viewFeatures.features.reserve(static_cast<int>(regionsPerView.at(vIdx)->RegionCount()));
@@ -512,7 +514,8 @@ bool MFeatures::updateFromTracks()
         const auto& trackIterator = tracks.find(trackId);
         if (trackIterator == tracks.end())
         {
-          qInfo() << "[QtAliceVision] Features: Update from tracks, track: " << trackId << " in current view: " << viewId << " does not exist in tracks";
+          qInfo() << "[QtAliceVision] Features: Update from tracks, track: " << trackId
+                  << " in current view: " << viewId << " does not exist in tracks";
           continue;
         }
         const aliceVision::track::Track& currentTrack = trackIterator->second;
@@ -620,11 +623,13 @@ bool MFeatures::updateFromSfM()
 
           if (itObs->second.id_feat < static_cast<uint>(viewFeatures.features.size()))
           {
-            viewFeatures.features.at(static_cast<int>(itObs->second.id_feat))->setLandmarkInfo(static_cast<int>(landmark.first), r.cast<float>());
+            viewFeatures.features.at(static_cast<int>(itObs->second.id_feat))->setLandmarkInfo(
+              static_cast<int>(landmark.first), r.cast<float>());
           }
           else if (!viewFeatures.features.empty())
           {
-            qWarning() << "[QtAliceVision] [ERROR] Features: Update from SfM, view: " << viewId << ", id_feat: " << itObs->second.id_feat << ", size: " << viewFeatures.features.size();
+            qWarning() << "[QtAliceVision] [ERROR] Features: Update from SfM, view: " << viewId << ", id_feat: "
+                       << itObs->second.id_feat << ", size: " << viewFeatures.features.size();
           }
 
           ++viewFeatures.nbLandmarks; // Update nb landmarks

--- a/src/MFeatures.cpp
+++ b/src/MFeatures.cpp
@@ -360,7 +360,7 @@ void MFeatures::getViewIdsToLoad(std::vector<aliceVision::IndexT>& viewIdsToLoad
       }
       else // time window
       {
-        const aliceVision::IndexT minFrameId = (currentFrameId < _timeWindow) ? 0 : currentFrameId - _timeWindow;
+        const aliceVision::IndexT minFrameId = (currentFrameId < (uint)_timeWindow) ? 0 : currentFrameId - _timeWindow;
         const aliceVision::IndexT maxFrameId = currentFrameId + _timeWindow;
 
         for (const auto& viewPair : sfmData.getViews())
@@ -534,8 +534,8 @@ bool MFeatures::updateFromTracks()
           continue;
         }
 
-        MFeature* feature = viewFeatures.features.at(featId);
-        feature->setTrackId(trackId);
+        MFeature* feature = viewFeatures.features.at((int)featId);
+        feature->setTrackId((int)trackId);
         ++viewFeatures.nbTracks;
         updated = true;
       }
@@ -619,7 +619,7 @@ bool MFeatures::updateFromSfM()
           // setup landmark id and landmark 2d reprojection in the current view
           aliceVision::Vec2 r = intrinsic->project(camTransform, landmark.second.X.homogeneous());
 
-          if (itObs->second.id_feat >= 0 && itObs->second.id_feat < viewFeatures.features.size())
+          if (itObs->second.id_feat >= 0 && itObs->second.id_feat < (uint)viewFeatures.features.size())
           {
             viewFeatures.features.at(itObs->second.id_feat)->setLandmarkInfo(landmark.first, r.cast<float>());
           }

--- a/src/MFeatures.cpp
+++ b/src/MFeatures.cpp
@@ -71,7 +71,7 @@ void FeaturesIORunnable::run()
 
     for (int dIdx = 0; dIdx < descTypes.size(); ++dIdx)
     {
-      std::vector<std::unique_ptr<aliceVision::feature::Regions>>& regionsPerView = regionsPerViewPerDesc.at((uint)dIdx);
+      std::vector<std::unique_ptr<aliceVision::feature::Regions>>& regionsPerView = regionsPerViewPerDesc.at(static_cast<uint>(dIdx));
 
       for (std::size_t vIdx = 0; vIdx < viewIds.size(); ++vIdx)
       {
@@ -360,8 +360,8 @@ void MFeatures::getViewIdsToLoad(std::vector<aliceVision::IndexT>& viewIdsToLoad
       }
       else // time window
       {
-        const aliceVision::IndexT minFrameId = (currentFrameId < (uint)_timeWindow) ? 0 : currentFrameId - (uint)_timeWindow;
-        const aliceVision::IndexT maxFrameId = currentFrameId + (uint)_timeWindow;
+        const aliceVision::IndexT minFrameId = (currentFrameId < static_cast<uint>(_timeWindow)) ? 0 : currentFrameId - static_cast<uint>(_timeWindow);
+        const aliceVision::IndexT maxFrameId = currentFrameId + static_cast<uint>(_timeWindow);
 
         for (const auto& viewPair : sfmData.getViews())
         {
@@ -382,7 +382,7 @@ void MFeatures::getViewIdsToLoad(std::vector<aliceVision::IndexT>& viewIdsToLoad
     return;
 
   // desciber types changed
-  if ((int)_viewFeaturesPerViewPerDesc.size() != _describerTypes.size())
+  if (static_cast<int>(_viewFeaturesPerViewPerDesc.size()) != _describerTypes.size())
   {
     clearAll(); // erase all data in memory
     return;
@@ -535,7 +535,7 @@ bool MFeatures::updateFromTracks()
         }
 
         MFeature* feature = viewFeatures.features.at(featId);
-        feature->setTrackId((int)trackId);
+        feature->setTrackId(static_cast<int>(trackId));
         ++viewFeatures.nbTracks;
         updated = true;
       }
@@ -619,9 +619,9 @@ bool MFeatures::updateFromSfM()
           // setup landmark id and landmark 2d reprojection in the current view
           aliceVision::Vec2 r = intrinsic->project(camTransform, landmark.second.X.homogeneous());
 
-          if (itObs->second.id_feat < (uint)viewFeatures.features.size())
+          if (itObs->second.id_feat < static_cast<uint>(viewFeatures.features.size()))
           {
-            viewFeatures.features.at((int)itObs->second.id_feat)->setLandmarkInfo((int)landmark.first, r.cast<float>());
+            viewFeatures.features.at(static_cast<int>(itObs->second.id_feat))->setLandmarkInfo(static_cast<int>(landmark.first), r.cast<float>());
           }
           else if (!viewFeatures.features.empty())
           {
@@ -697,7 +697,7 @@ void MFeatures::updatePerTrackInformation()
       {
         if (feature->trackId() >= 0)
         {
-          unsigned int unsignedTrackId = (uint)feature->trackId();
+          unsigned int unsignedTrackId = static_cast<uint>(feature->trackId());
           MTrackFeatures& trackFreatures = _trackFeaturesPerTrackPerDesc[describerType][unsignedTrackId];
           trackFreatures.featuresPerFrame[frameId] = feature;
 
@@ -706,7 +706,7 @@ void MFeatures::updatePerTrackInformation()
           if (feature->landmarkId() >= 0)
           {
             ++trackFreatures.nbLandmarks;
-            const auto unsignedLandmarkId = (uint)feature->landmarkId();
+            const auto unsignedLandmarkId = static_cast<uint>(feature->landmarkId());
             if (trackIdPerLandmark.find(unsignedLandmarkId) == trackIdPerLandmark.end())
               trackIdPerLandmark[unsignedLandmarkId] = unsignedTrackId;
           }
@@ -731,7 +731,7 @@ void MFeatures::updatePerTrackInformation()
       MTrackFeatures& trackFreatures = trackFeaturesPerTrackPair.second;
 
       if (!trackFreatures.featuresPerFrame.empty())
-        trackFreatures.featureScaleAverage /= (float)trackFreatures.featuresPerFrame.size();
+        trackFreatures.featureScaleAverage /= static_cast<float>(trackFreatures.featuresPerFrame.size());
     }
   }
 

--- a/src/MFeatures.cpp
+++ b/src/MFeatures.cpp
@@ -173,7 +173,7 @@ void MFeatures::load()
     return;
   }
 
-  if(_currentViewId == aliceVision::UndefinedIndexT)
+  if (_currentViewId == aliceVision::UndefinedIndexT)
   {
     setStatus(None);
     return;
@@ -339,7 +339,7 @@ void MFeatures::getViewIdsToLoad(std::vector<aliceVision::IndexT>& viewIdsToLoad
     try
     {
       currentIntrinsicId = sfmData.getView(_currentViewId).getIntrinsicId();
-      currentFrameId = sfmData.getView(_currentViewId).getFrameId();;
+      currentFrameId = sfmData.getView(_currentViewId).getFrameId();
     }
     catch (std::exception& e)
     {
@@ -356,7 +356,6 @@ void MFeatures::getViewIdsToLoad(std::vector<aliceVision::IndexT>& viewIdsToLoad
           if ((currentIntrinsicId == view.getIntrinsicId() && (view.getFrameId() != aliceVision::UndefinedIndexT)))
               viewIdsToLoad.emplace_back(view.getViewId());
         }
-
       }
       else // time window
       {
@@ -376,7 +375,7 @@ void MFeatures::getViewIdsToLoad(std::vector<aliceVision::IndexT>& viewIdsToLoad
   // single view
   if (viewIdsToLoad.empty())
     viewIdsToLoad.emplace_back(_currentViewId);
-  
+
   // first initialization
   if (_viewFeaturesPerViewPerDesc.empty())
     return;
@@ -398,7 +397,7 @@ void MFeatures::getViewIdsToLoad(std::vector<aliceVision::IndexT>& viewIdsToLoad
   for (const auto& viewFeaturesPerViewPair : viewFeaturesPerView)
   {
     bool toKeep = false;
-      
+
     for (aliceVision::IndexT viewId : viewIdsToLoad)
     {
       if (viewFeaturesPerViewPair.first == viewId)
@@ -409,7 +408,7 @@ void MFeatures::getViewIdsToLoad(std::vector<aliceVision::IndexT>& viewIdsToLoad
       }
     }
 
-    if(!toKeep)
+    if (!toKeep)
       viewIdsToRemove.push_back(viewFeaturesPerViewPair.first);
   }
 
@@ -450,8 +449,8 @@ void MFeatures::getViewIdsToLoad(std::vector<aliceVision::IndexT>& viewIdsToLoad
       viewIdsToLoad.erase(iter);
   }
 
-  qDebug() << "[QtAliceVision] Features: Caching: " << viewIdsToKeep.size() << " frame(s) kept, " 
-                                                    << viewIdsToRemove.size() << " frame(s) removed, " 
+  qDebug() << "[QtAliceVision] Features: Caching: " << viewIdsToKeep.size() << " frame(s) kept, "
+                                                    << viewIdsToRemove.size() << " frame(s) removed, "
                                                     << viewIdsToLoad.size() << " frame(s) requested.";
 }
 
@@ -495,7 +494,7 @@ bool MFeatures::updateFromTracks()
       const aliceVision::IndexT viewId = viewFeaturesPerViewPair.first;
       MViewFeatures& viewFeatures = viewFeaturesPerViewPair.second;
 
-      if (viewFeatures.nbTracks > 0) // view already update 
+      if (viewFeatures.nbTracks > 0) // view already update
         continue;
 
       auto tracksPerViewIt = _mtracks->tracksPerView().find(viewId);
@@ -682,7 +681,7 @@ void MFeatures::updatePerTrackInformation()
   {
     const QString& describerType = viewFeaturesPerViewPerDescPair.first;
 
-    if (viewFeaturesPerViewPerDescPair.second.size() < 2) 
+    if (viewFeaturesPerViewPerDescPair.second.size() < 2)
       continue; // to build _trackFeaturesPerTrackPerDesc we need at least 2 views per desc
 
     for (auto& viewFeaturesPerViewPair : viewFeaturesPerViewPerDescPair.second)
@@ -713,7 +712,7 @@ void MFeatures::updatePerTrackInformation()
 
           trackFreatures.maxFrameId = std::max(trackFreatures.maxFrameId, frameId);
           trackFreatures.minFrameId = std::min(trackFreatures.minFrameId, frameId);
-          trackFreatures.featureScaleAverage += feature->scale(); // initialize score with feature scale sum
+          trackFreatures.featureScaleAverage += feature->scale();  // initialize score with feature scale sum
         }
       }
     }
@@ -723,7 +722,7 @@ void MFeatures::updatePerTrackInformation()
   if (_trackFeaturesPerTrackPerDesc.empty())
     return;
 
-  // compute average feature scale 
+  // compute average feature scale
   for (auto& trackFeaturesPerTrackPerDescPair : _trackFeaturesPerTrackPerDesc)
   {
     for (auto& trackFeaturesPerTrackPair : trackFeaturesPerTrackPerDescPair.second)
@@ -746,7 +745,7 @@ void MFeatures::updatePerTrackInformation()
 
     const aliceVision::IndexT trackId = trackIdIt->second;
     auto& trackFeatures = _trackFeaturesPerTrackPerDesc[describerTypeName][trackId];
-    
+
     for (auto& featuresPerFramePair : trackFeatures.featuresPerFrame)
     {
       if (featuresPerFramePair.second->landmarkId() >= 0)

--- a/src/MFeatures.hpp
+++ b/src/MFeatures.hpp
@@ -23,7 +23,7 @@ class MFeatures : public QObject
     Q_OBJECT
 
     /// Data properties
-    
+
     // Path to folder containing the features
     Q_PROPERTY(QUrl featureFolder MEMBER _featureFolder NOTIFY featureFolderChanged)
     // Describer types to load
@@ -83,7 +83,7 @@ public:
 
       aliceVision::IndexT minFrameId = std::numeric_limits<aliceVision::IndexT>::max();
       aliceVision::IndexT maxFrameId = std::numeric_limits<aliceVision::IndexT>::min();
-      int nbLandmarks = 0;             // number of features of the track associated to a 3D landmark 
+      int nbLandmarks = 0;             // number of features of the track associated to a 3D landmark
       float featureScaleAverage = 0.f; // average feature scale
     };
     using MTrackFeaturesPerTrack = std::map<aliceVision::IndexT, MTrackFeatures>;
@@ -201,12 +201,12 @@ public:
      * @see MFeatures status enum
      * @return MFeatures status enum
      */
-    Status status() const 
-    { 
-      return _status; 
+    Status status() const
+    {
+      return _status;
     }
 
-    void setStatus(Status status) 
+    void setStatus(Status status)
     {
       if (status == _status)
         return;
@@ -219,7 +219,7 @@ public:
     }
 
 private:
-    
+
     /// Private methods (to use with Loading status)
 
     /**
@@ -265,7 +265,7 @@ private:
     void clearAllSfMInfo();
     void clearAllFeatureReprojection();
     void clearAll();
-    
+
     /// Private members
 
     // inputs

--- a/src/MSfMData.cpp
+++ b/src/MSfMData.cpp
@@ -92,7 +92,6 @@ void MSfMData::load()
     }
     if (!(status() == Loading))
     {
-
         setStatus(Loading);
 
         _loadingSfmData->clear();
@@ -115,7 +114,7 @@ void MSfMData::onSfmDataReady()
     if(!_loadingSfmData)
         return;
 
-    if (_outdated) 
+    if (_outdated)
     {
         clear();
         setStatus(None);

--- a/src/MSfMData.hpp
+++ b/src/MSfMData.hpp
@@ -20,7 +20,7 @@ class MSfMData : public QObject
 
     Q_PROPERTY(QUrl sfmDataPath READ getSfmDataPath WRITE setSfmDataPath NOTIFY sfmDataPathChanged)
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
-    Q_PROPERTY(int nbCameras READ nbCameras NOTIFY statusChanged)
+    Q_PROPERTY(size_t nbCameras READ nbCameras NOTIFY statusChanged)
     Q_PROPERTY(QVariantList viewsIds READ getViewsIds NOTIFY viewsIdsChanged)
 
 public:
@@ -88,7 +88,7 @@ public:
        }
     }
 
-    inline int nbCameras() const {
+    inline size_t nbCameras() const {
         if(!_sfmData || _status != Ready)
             return 0;
         return _sfmData->getValidViews().size();

--- a/src/MSfMData.hpp
+++ b/src/MSfMData.hpp
@@ -105,8 +105,8 @@ public:
 
 private:
     QUrl _sfmDataPath;
-    std::unique_ptr<aliceVision::sfmData::SfMData> _loadingSfmData;
     std::unique_ptr<aliceVision::sfmData::SfMData> _sfmData;
+    std::unique_ptr<aliceVision::sfmData::SfMData> _loadingSfmData;
     Status _status = MSfMData::None;
     bool _outdated = false;
 };

--- a/src/MSfMDataStats.cpp
+++ b/src/MSfMDataStats.cpp
@@ -69,9 +69,9 @@ void MSfMDataStats::fillResidualsMinPerViewSerie(QXYSeries* residualsPerView)
         return;
     }
 
-    for(int i = 0; i < _nbResidualsPerViewMin.size(); ++i)
+    for(std::size_t i = 0; i < _nbResidualsPerViewMin.size(); ++i)
     {
-        residualsPerView->append(i, double(_nbResidualsPerViewMin[i]));
+        residualsPerView->append(double(i), double(_nbResidualsPerViewMin[i]));
     }
 }
 
@@ -90,9 +90,9 @@ void MSfMDataStats::fillResidualsMaxPerViewSerie(QXYSeries* residualsPerView)
         return;
     }
 
-    for(int i = 0; i < _nbResidualsPerViewMax.size(); ++i)
+    for(std::size_t i = 0; i < _nbResidualsPerViewMax.size(); ++i)
     {
-        residualsPerView->append(i, double(_nbResidualsPerViewMax[i]));
+        residualsPerView->append(double(i), double(_nbResidualsPerViewMax[i]));
     }
 }
 
@@ -111,9 +111,9 @@ void MSfMDataStats::fillResidualsMeanPerViewSerie(QXYSeries* residualsPerView)
         return;
     }
 
-    for(int i = 0; i < _nbResidualsPerViewMean.size(); ++i)
+    for(std::size_t i = 0; i < _nbResidualsPerViewMean.size(); ++i)
     {
-        residualsPerView->append(i, double(_nbResidualsPerViewMean[i]));
+        residualsPerView->append(double(i), double(_nbResidualsPerViewMean[i]));
     }
 }
 
@@ -132,9 +132,9 @@ void MSfMDataStats::fillResidualsMedianPerViewSerie(QXYSeries* residualsPerView)
         return;
     }
 
-    for(int i = 0; i < _nbResidualsPerViewMedian.size(); ++i)
+    for(std::size_t i = 0; i < _nbResidualsPerViewMedian.size(); ++i)
     {
-        residualsPerView->append(i, double(_nbResidualsPerViewMedian[i]));
+        residualsPerView->append(double(i), double(_nbResidualsPerViewMedian[i]));
     }
 }
 
@@ -153,9 +153,9 @@ void MSfMDataStats::fillResidualsFirstQuartilePerViewSerie(QXYSeries* residualsP
         return;
     }
 
-    for(int i = 0; i < _nbResidualsPerViewFirstQuartile.size(); ++i)
+    for(std::size_t i = 0; i < _nbResidualsPerViewFirstQuartile.size(); ++i)
     {
-        residualsPerView->append(i, double(_nbResidualsPerViewFirstQuartile[i]));
+        residualsPerView->append(double(i), double(_nbResidualsPerViewFirstQuartile[i]));
     }
 }
 
@@ -174,9 +174,9 @@ void MSfMDataStats::fillResidualsThirdQuartilePerViewSerie(QXYSeries* residualsP
         return;
     }
 
-    for(int i = 0; i < _nbResidualsPerViewThirdQuartile.size(); ++i)
+    for(std::size_t i = 0; i < _nbResidualsPerViewThirdQuartile.size(); ++i)
     {
-        residualsPerView->append(i, double(_nbResidualsPerViewThirdQuartile[i]));
+        residualsPerView->append(double(i), double(_nbResidualsPerViewThirdQuartile[i]));
     }
 }
 
@@ -195,9 +195,9 @@ void MSfMDataStats::fillObservationsLengthsMinPerViewSerie(QXYSeries* observatio
         return;
     }
 
-    for(int i = 0; i < _nbObservationsLengthsPerViewMin.size(); ++i)
+    for(std::size_t i = 0; i < _nbObservationsLengthsPerViewMin.size(); ++i)
     {
-        observationsLengthsPerView->append(i, double(_nbObservationsLengthsPerViewMin[i]));
+        observationsLengthsPerView->append(double(i), double(_nbObservationsLengthsPerViewMin[i]));
     }
 }
 
@@ -216,9 +216,9 @@ void MSfMDataStats::fillObservationsLengthsMaxPerViewSerie(QXYSeries* observatio
         return;
     }
 
-    for(int i = 0; i < _nbObservationsLengthsPerViewMax.size(); ++i)
+    for(std::size_t i = 0; i < _nbObservationsLengthsPerViewMax.size(); ++i)
     {
-        observationsLengthsPerView->append(i, double(_nbObservationsLengthsPerViewMax[i]));
+        observationsLengthsPerView->append(double(i), double(_nbObservationsLengthsPerViewMax[i]));
     }
 }
 
@@ -237,9 +237,9 @@ void MSfMDataStats::fillObservationsLengthsMeanPerViewSerie(QXYSeries* observati
         return;
     }
 
-    for(int i = 0; i < _nbObservationsLengthsPerViewMean.size(); ++i)
+    for(std::size_t i = 0; i < _nbObservationsLengthsPerViewMean.size(); ++i)
     {
-        observationsLengthsPerView->append(i, double(_nbObservationsLengthsPerViewMean[i]));
+        observationsLengthsPerView->append(double(i), double(_nbObservationsLengthsPerViewMean[i]));
     }
 }
 
@@ -258,9 +258,9 @@ void MSfMDataStats::fillObservationsLengthsMedianPerViewSerie(QXYSeries* observa
         return;
     }
 
-    for(int i = 0; i < _nbObservationsLengthsPerViewMedian.size(); ++i)
+    for(std::size_t i = 0; i < _nbObservationsLengthsPerViewMedian.size(); ++i)
     {
-        observationsLengthsPerView->append(i, double(_nbObservationsLengthsPerViewMedian[i]));
+        observationsLengthsPerView->append(double(i), double(_nbObservationsLengthsPerViewMedian[i]));
     }
 }
 
@@ -279,9 +279,9 @@ void MSfMDataStats::fillObservationsLengthsFirstQuartilePerViewSerie(QXYSeries* 
         return;
     }
 
-    for(int i = 0; i < _nbObservationsLengthsPerViewFirstQuartile.size(); ++i)
+    for(std::size_t i = 0; i < _nbObservationsLengthsPerViewFirstQuartile.size(); ++i)
     {
-        observationsLengthsPerView->append(i, double(_nbObservationsLengthsPerViewFirstQuartile[i]));
+        observationsLengthsPerView->append(double(i), double(_nbObservationsLengthsPerViewFirstQuartile[i]));
     }
 }
 
@@ -300,9 +300,9 @@ void MSfMDataStats::fillObservationsLengthsThirdQuartilePerViewSerie(QXYSeries* 
         return;
     }
 
-    for(int i = 0; i < _nbObservationsLengthsPerViewThirdQuartile.size(); ++i)
+    for(std::size_t i = 0; i < _nbObservationsLengthsPerViewThirdQuartile.size(); ++i)
     {
-        observationsLengthsPerView->append(i, double(_nbObservationsLengthsPerViewThirdQuartile[i]));
+        observationsLengthsPerView->append(double(i), double(_nbObservationsLengthsPerViewThirdQuartile[i]));
     }
 }
 
@@ -348,7 +348,7 @@ void MSfMDataStats::computeGlobalSfMStats()
         _nbLandmarksPerView.resize(nbLandmarksPerView.size());
         std::copy(nbLandmarksPerView.begin(), nbLandmarksPerView.end(), _nbLandmarksPerView.begin());
 
-        _landmarksPerViewMaxAxisX = round(_msfmData->rawData().getViews().size());
+        _landmarksPerViewMaxAxisX = (int)_msfmData->rawData().getViews().size();
         _landmarksPerViewMaxAxisY = 0.0;
 
         for(int v: nbLandmarksPerView)
@@ -365,7 +365,7 @@ void MSfMDataStats::computeGlobalSfMStats()
        sfm::computeResidualsPerView(_msfmData->rawData(), _residualsPerViewMaxAxisX, _nbResidualsPerViewMin, _nbResidualsPerViewMax, _nbResidualsPerViewMean, _nbResidualsPerViewMedian, _nbResidualsPerViewFirstQuartile, _nbResidualsPerViewThirdQuartile);
        _residualsPerViewMaxAxisY = 0.0;
 
-       for(int i = 0; i < _nbResidualsPerViewMin.size(); ++i)
+       for(std::size_t i = 0; i < _nbResidualsPerViewMin.size(); ++i)
        {
            _residualsPerViewMaxAxisY = round(std::max(_residualsPerViewMaxAxisY, double(_nbResidualsPerViewMin[i])));
            _residualsPerViewMaxAxisY = round(std::max(_residualsPerViewMaxAxisY, double(_nbResidualsPerViewMax[i])));
@@ -385,7 +385,7 @@ void MSfMDataStats::computeGlobalSfMStats()
        sfm::computeObservationsLengthsPerView(_msfmData->rawData(), _observationsLengthsPerViewMaxAxisX, _nbObservationsLengthsPerViewMin, _nbObservationsLengthsPerViewMax, _nbObservationsLengthsPerViewMean, _nbObservationsLengthsPerViewMedian, _nbObservationsLengthsPerViewFirstQuartile, _nbObservationsLengthsPerViewThirdQuartile);
        _observationsLengthsPerViewMaxAxisY = 0.0;
 
-       for(int i = 0; i < _nbObservationsLengthsPerViewMin.size(); ++i)
+       for(std::size_t i = 0; i < _nbObservationsLengthsPerViewMin.size(); ++i)
        {
            _observationsLengthsPerViewMaxAxisY = round(std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewMin[i])));
            _observationsLengthsPerViewMaxAxisY = round(std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewMax[i])));
@@ -437,14 +437,14 @@ void MSfMDataStats::computeGlobalTracksStats()
             const auto viewId = viewIt.first;
 
             if(_mTracks->tracksPerView().count(viewId))
-                _nbTracksPerView.push_back(_mTracks->tracksPerView().at(viewId).size());
+                _nbTracksPerView.push_back(double(_mTracks->tracksPerView().at(viewId).size()));
             else
-                _nbTracksPerView.push_back(0);
+                _nbTracksPerView.push_back(0.0);
         }
 
-        for(int v: _nbTracksPerView)
+        for(double v: _nbTracksPerView)
         {
-            _landmarksPerViewMaxAxisY = std::max(_landmarksPerViewMaxAxisY, double(v));
+            _landmarksPerViewMaxAxisY = std::max(_landmarksPerViewMaxAxisY, v);
         }
 
     Q_EMIT tracksStatsChanged();

--- a/src/MSfMDataStats.cpp
+++ b/src/MSfMDataStats.cpp
@@ -382,7 +382,10 @@ void MSfMDataStats::computeGlobalSfMStats()
     //Observations Lengths Per View graph
     {
        _observationsLengthsPerViewMaxAxisX = 0;
-       sfm::computeObservationsLengthsPerView(_msfmData->rawData(), _observationsLengthsPerViewMaxAxisX, _nbObservationsLengthsPerViewMin, _nbObservationsLengthsPerViewMax, _nbObservationsLengthsPerViewMean, _nbObservationsLengthsPerViewMedian, _nbObservationsLengthsPerViewFirstQuartile, _nbObservationsLengthsPerViewThirdQuartile);
+       sfm::computeObservationsLengthsPerView(_msfmData->rawData(), _observationsLengthsPerViewMaxAxisX,
+        _nbObservationsLengthsPerViewMin, _nbObservationsLengthsPerViewMax, _nbObservationsLengthsPerViewMean,
+        _nbObservationsLengthsPerViewMedian, _nbObservationsLengthsPerViewFirstQuartile,
+        _nbObservationsLengthsPerViewThirdQuartile);
        _observationsLengthsPerViewMaxAxisY = 0.0;
 
        for(std::size_t i = 0; i < _nbObservationsLengthsPerViewMin.size(); ++i)

--- a/src/MSfMDataStats.cpp
+++ b/src/MSfMDataStats.cpp
@@ -348,7 +348,7 @@ void MSfMDataStats::computeGlobalSfMStats()
         _nbLandmarksPerView.resize(nbLandmarksPerView.size());
         std::copy(nbLandmarksPerView.begin(), nbLandmarksPerView.end(), _nbLandmarksPerView.begin());
 
-        _landmarksPerViewMaxAxisX = (int)_msfmData->rawData().getViews().size();
+        _landmarksPerViewMaxAxisX = static_cast<int>(_msfmData->rawData().getViews().size());
         _landmarksPerViewMaxAxisY = 0.0;
 
         for(int v: nbLandmarksPerView)

--- a/src/MTracks.cpp
+++ b/src/MTracks.cpp
@@ -19,7 +19,6 @@ class TracksIORunnable : public QObject, public QRunnable
     Q_OBJECT
 
 public:
-
     explicit TracksIORunnable(const QUrl& matchingFolder):
     _matchingFolder(matchingFolder)
     {}

--- a/src/MTracks.hpp
+++ b/src/MTracks.hpp
@@ -74,7 +74,6 @@ public:
 
     QUrl getMatchingFolder() const { return _matchingFolder; }
     void setMatchingFolder(const QUrl& matchingFolder) {
-
         if(matchingFolder == _matchingFolder)
             return;
        _matchingFolder = matchingFolder;
@@ -104,7 +103,6 @@ private:
     std::unique_ptr<aliceVision::track::TracksMap> _tracks;
     std::unique_ptr<aliceVision::track::TracksPerView> _tracksPerView;
     Status _status = MTracks::None;
-
 };
 
 }

--- a/src/MTracks.hpp
+++ b/src/MTracks.hpp
@@ -20,7 +20,7 @@ class MTracks : public QObject
 
     Q_PROPERTY(QUrl matchingFolder READ getMatchingFolder WRITE setMatchingFolder NOTIFY matchingFolderChanged)
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
-    Q_PROPERTY(int nbTracks READ nbTracks CONSTANT)
+    Q_PROPERTY(size_t nbTracks READ nbTracks CONSTANT)
 
 public:
     enum Status {
@@ -93,7 +93,7 @@ public:
        }
     }
 
-    inline int nbTracks() const {
+    inline size_t nbTracks() const {
         if(!_tracks || _status != MTracks::Ready)
             return 0;
         return _tracks->size();

--- a/src/MViewStats.cpp
+++ b/src/MViewStats.cpp
@@ -243,7 +243,7 @@ void MViewStats::computeViewStats()
             std::vector<size_t>& residualFullHistY = _residualHistogramFull.GetHist();
             for(std::size_t i = 0; i < residualFullHistY.size(); ++i)
             {
-                residualFullHistY[i] = (size_t)round((double)residualFullHistY[i] / nbCameras);
+                residualFullHistY[i] = static_cast<size_t>(round(static_cast<double>(residualFullHistY[i]) / nbCameras));
             }
             std::vector<double> residualHistX = _residualHistogramFull.GetXbinsValue();
             assert(residualHistX.size() == residualFullHistY.size());
@@ -285,7 +285,7 @@ void MViewStats::computeViewStats()
             // normalize the histogram to get the average number of observations
             for(std::size_t i = 0; i < observationsLengthsFullHistY.size(); ++i)
             {
-                observationsLengthsFullHistY[i] = (size_t)round((double)observationsLengthsFullHistY[i] / nbCameras);
+                observationsLengthsFullHistY[i] = static_cast<size_t>(round(static_cast<double>(observationsLengthsFullHistY[i]) / nbCameras));
             }
             std::vector<double> observationsLengthsHistX = _observationsLengthsHistogramFull.GetXbinsValue();
             assert(observationsLengthsHistX.size() == observationsLengthsFullHistY.size());
@@ -323,7 +323,7 @@ void MViewStats::computeViewStats()
         std::vector<size_t>& observationsScaleFullHistY = _observationsScaleHistogramFull.GetHist();
         for(std::size_t i = 0; i < observationsScaleFullHistY.size(); ++i)
         {
-            observationsScaleFullHistY[i] = (std::size_t)std::round((double)observationsScaleFullHistY[i] / nbCameras);
+            observationsScaleFullHistY[i] = static_cast<std::size_t>(std::round(static_cast<double>(observationsScaleFullHistY[i]) / nbCameras));
         }
         std::vector<double> observationsScaleHistX = _observationsScaleHistogramFull.GetXbinsValue();
         assert(observationsScaleHistX.size() == observationsScaleFullHistY.size());

--- a/src/MViewStats.cpp
+++ b/src/MViewStats.cpp
@@ -200,7 +200,6 @@ void MViewStats::fillObservationsScaleViewSerie(QXYSeries* observationsScale)
         observationsScale->append(double(observationsScaleHistX[i]), double(observationsScaleHistY[i]));
         observationsScale->setPen(pen);
     }
-
 }
 
 
@@ -269,7 +268,7 @@ void MViewStats::computeViewStats()
         }
     }
 
-    _nbObservations = 0; 
+    _nbObservations = 0;
     {
         _observationsLengthsMaxAxisX = 0.0;
         _observationsLengthsMaxAxisY = 0.0;
@@ -359,7 +358,7 @@ void MViewStats::setMSfmData(qtAliceVision::MSfMData* sfmData)
     }
     _msfmData = sfmData;
     if(_msfmData != nullptr)
-    {        
+    {
         connect(_msfmData, SIGNAL(sfmDataChanged()), this, SIGNAL(sfmDataChanged()));
     }
     Q_EMIT sfmDataChanged();

--- a/src/MViewStats.cpp
+++ b/src/MViewStats.cpp
@@ -243,7 +243,7 @@ void MViewStats::computeViewStats()
             std::vector<size_t>& residualFullHistY = _residualHistogramFull.GetHist();
             for(std::size_t i = 0; i < residualFullHistY.size(); ++i)
             {
-                residualFullHistY[i] = std::round(residualFullHistY[i] / nbCameras);
+                residualFullHistY[i] = (size_t)round((double)residualFullHistY[i] / nbCameras);
             }
             std::vector<double> residualHistX = _residualHistogramFull.GetXbinsValue();
             assert(residualHistX.size() == residualFullHistY.size());
@@ -285,7 +285,7 @@ void MViewStats::computeViewStats()
             // normalize the histogram to get the average number of observations
             for(std::size_t i = 0; i < observationsLengthsFullHistY.size(); ++i)
             {
-                observationsLengthsFullHistY[i] = round(observationsLengthsFullHistY[i] / nbCameras);
+                observationsLengthsFullHistY[i] = (size_t)round((double)observationsLengthsFullHistY[i] / nbCameras);
             }
             std::vector<double> observationsLengthsHistX = _observationsLengthsHistogramFull.GetXbinsValue();
             assert(observationsLengthsHistX.size() == observationsLengthsFullHistY.size());
@@ -323,7 +323,7 @@ void MViewStats::computeViewStats()
         std::vector<size_t>& observationsScaleFullHistY = _observationsScaleHistogramFull.GetHist();
         for(std::size_t i = 0; i < observationsScaleFullHistY.size(); ++i)
         {
-            observationsScaleFullHistY[i] = std::round(observationsScaleFullHistY[i] / nbCameras);
+            observationsScaleFullHistY[i] = (std::size_t)std::round((double)observationsScaleFullHistY[i] / nbCameras);
         }
         std::vector<double> observationsScaleHistX = _observationsScaleHistogramFull.GetXbinsValue();
         assert(observationsScaleHistX.size() == observationsScaleFullHistY.size());

--- a/src/MViewStats.hpp
+++ b/src/MViewStats.hpp
@@ -26,17 +26,17 @@ class MViewStats : public QObject
     /// Pointer to sfmData
     Q_PROPERTY(qtAliceVision::MSfMData* msfmData READ getMSfmData WRITE setMSfmData NOTIFY sfmDataChanged)
     /// max AxisX value for reprojection residual histogram
-    Q_PROPERTY(int residualMaxAxisX MEMBER _residualMaxAxisX NOTIFY viewStatsChanged)
+    Q_PROPERTY(double residualMaxAxisX MEMBER _residualMaxAxisX NOTIFY viewStatsChanged)
     /// max AxisY value for reprojection residual histogram
-    Q_PROPERTY(int residualMaxAxisY MEMBER _residualMaxAxisY NOTIFY viewStatsChanged)
+    Q_PROPERTY(double residualMaxAxisY MEMBER _residualMaxAxisY NOTIFY viewStatsChanged)
     /// max AxisX value for observations lengths histogram
-    Q_PROPERTY(int observationsLengthsMaxAxisX MEMBER _observationsLengthsMaxAxisX NOTIFY viewStatsChanged)
+    Q_PROPERTY(double observationsLengthsMaxAxisX MEMBER _observationsLengthsMaxAxisX NOTIFY viewStatsChanged)
     /// max AxisY value for observations lengths histogram
-    Q_PROPERTY(int observationsLengthsMaxAxisY MEMBER _observationsLengthsMaxAxisY NOTIFY viewStatsChanged)
+    Q_PROPERTY(double observationsLengthsMaxAxisY MEMBER _observationsLengthsMaxAxisY NOTIFY viewStatsChanged)
     /// max AxisX value for scale histogram
-    Q_PROPERTY(int observationsScaleMaxAxisX MEMBER _observationsScaleMaxAxisX NOTIFY viewStatsChanged)
+    Q_PROPERTY(double observationsScaleMaxAxisX MEMBER _observationsScaleMaxAxisX NOTIFY viewStatsChanged)
     /// max AxisY value for scale histogram
-    Q_PROPERTY(int observationsScaleMaxAxisY MEMBER _observationsScaleMaxAxisY NOTIFY viewStatsChanged)
+    Q_PROPERTY(double observationsScaleMaxAxisY MEMBER _observationsScaleMaxAxisY NOTIFY viewStatsChanged)
 
 public:
     MViewStats()
@@ -86,4 +86,4 @@ private:
 
 }
 
-Q_DECLARE_METATYPE(QPointF);   // for usage in signals/slots/properties
+Q_DECLARE_METATYPE(QPointF)   // for usage in signals/slots/properties

--- a/src/PanoramaViewer.cpp
+++ b/src/PanoramaViewer.cpp
@@ -40,20 +40,20 @@ void PanoramaViewer::computeDownscale()
 
     int totalSizeImages = 0;
     for (const auto& view : _msfmData->rawData().getViews())
-        totalSizeImages += int(((view.second->getWidth() * view.second->getHeight()) * 4) / std::pow(10, 6));
+        totalSizeImages += int((double)((view.second->getWidth() * view.second->getHeight()) * 4) / std::pow(10, 6));
 
     // Downscale = 4 by default
     _downscale = 4;
-    for (size_t i = 0; i < _downscale; i++) 
-        totalSizeImages *= 0.5;
+    for (int i = 0; i < _downscale; i++)
+        totalSizeImages = (int)(totalSizeImages * 0.5);
 
     // ensure it fits in RAM memory
     aliceVision::system::MemoryInfo memInfo = aliceVision::system::getMemoryInfo();
-    const int freeRam = int(memInfo.freeRam / std::pow(2, 20));
+    const int freeRam = int((double)memInfo.freeRam / std::pow(2, 20));
     while (totalSizeImages > freeRam * 0.5)
     {
         _downscale++;
-        totalSizeImages *= 0.5;
+        totalSizeImages = (int)(totalSizeImages * 0.5);
     }
 
     Q_EMIT downscaleReady();
@@ -61,6 +61,7 @@ void PanoramaViewer::computeDownscale()
 
 QSGNode* PanoramaViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdatePaintNodeData* data)
 {
+    (void)data; // Fix "unused parameter" warnings; should be replaced by [[maybe_unused]] when C++17 is supported
     QSGGeometryNode* root = static_cast<QSGGeometryNode*>(oldNode);
     return root;
 }

--- a/src/PanoramaViewer.cpp
+++ b/src/PanoramaViewer.cpp
@@ -40,20 +40,20 @@ void PanoramaViewer::computeDownscale()
 
     int totalSizeImages = 0;
     for (const auto& view : _msfmData->rawData().getViews())
-        totalSizeImages += int((double)((view.second->getWidth() * view.second->getHeight()) * 4) / std::pow(10, 6));
+        totalSizeImages += int(static_cast<double>((view.second->getWidth() * view.second->getHeight()) * 4) / std::pow(10, 6));
 
     // Downscale = 4 by default
     _downscale = 4;
     for (int i = 0; i < _downscale; i++)
-        totalSizeImages = (int)(totalSizeImages * 0.5);
+        totalSizeImages = static_cast<int>(totalSizeImages * 0.5);
 
     // ensure it fits in RAM memory
     aliceVision::system::MemoryInfo memInfo = aliceVision::system::getMemoryInfo();
-    const int freeRam = int((double)memInfo.freeRam / std::pow(2, 20));
+    const int freeRam = int(static_cast<double>(memInfo.freeRam) / std::pow(2, 20));
     while (totalSizeImages > freeRam * 0.5)
     {
         _downscale++;
-        totalSizeImages = (int)(totalSizeImages * 0.5);
+        totalSizeImages = static_cast<int>(totalSizeImages * 0.5);
     }
 
     Q_EMIT downscaleReady();

--- a/src/PanoramaViewer.cpp
+++ b/src/PanoramaViewer.cpp
@@ -68,7 +68,6 @@ QSGNode* PanoramaViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdatePai
 
 void PanoramaViewer::setMSfmData(MSfMData* sfmData)
 {
-
     if (_msfmData == sfmData)
         return;
 

--- a/src/PanoramaViewer.hpp
+++ b/src/PanoramaViewer.hpp
@@ -66,7 +66,7 @@ namespace qtAliceVision
 
     private:
         QSize _sourceSize = QSize(3000, 1500);
-        
+
         MSfMData* _msfmData = nullptr;
 
         int _downscale = 4;
@@ -75,5 +75,3 @@ namespace qtAliceVision
 }  // ns qtAliceVision
 
 Q_DECLARE_METATYPE(QList<QPoint>)
-
-

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -53,7 +53,7 @@ void Surface::computeGrid(QSGGeometry::TexturedPoint2D* vertices, quint16* indic
     if (_sfmLoaded && (_isPanoramaRotating || _needToUseIntrinsic))
     {
         // Load Intrinsic with 2 ways whether we are in the Panorama or Distorsion Viewer
-        if (_msfmData && _idView >= 0)
+        if (_msfmData)
         {
             intrinsic = getIntrinsicFromViewId(_idView);
         }
@@ -87,9 +87,9 @@ void Surface::computeGrid(QSGGeometry* geometryLine)
 
     int countPoint = 0;
     int index = 0;
-    for (size_t i = 0; i <= _subdivisions; i++)
+    for (int i = 0; i <= _subdivisions; i++)
     {
-        for (size_t j = 0; j <= _subdivisions; j++)
+        for (int j = 0; j <= _subdivisions; j++)
         {
             if (i == _subdivisions && j == _subdivisions)
                 continue;
@@ -97,9 +97,9 @@ void Surface::computeGrid(QSGGeometry* geometryLine)
             // Horizontal Lines
             if (i != _subdivisions)
             {
-                geometryLine->vertexDataAsPoint2D()[countPoint++].set(_vertices[index].x(), _vertices[index].y());
+                geometryLine->vertexDataAsPoint2D()[countPoint++].set((float)_vertices[index].x(), (float)_vertices[index].y());
                 index += _subdivisions + 1;
-                geometryLine->vertexDataAsPoint2D()[countPoint++].set(_vertices[index].x(), _vertices[index].y());
+                geometryLine->vertexDataAsPoint2D()[countPoint++].set((float)_vertices[index].x(), (float)_vertices[index].y());
                 index -= _subdivisions + 1;
 
                 if (j == _subdivisions)
@@ -110,9 +110,9 @@ void Surface::computeGrid(QSGGeometry* geometryLine)
             }
 
             // Vertical Lines
-            geometryLine->vertexDataAsPoint2D()[countPoint++].set(_vertices[index].x(), _vertices[index].y());
+            geometryLine->vertexDataAsPoint2D()[countPoint++].set((float)_vertices[index].x(), (float)_vertices[index].y());
             index++;
-            geometryLine->vertexDataAsPoint2D()[countPoint++].set(_vertices[index].x(), _vertices[index].y());
+            geometryLine->vertexDataAsPoint2D()[countPoint++].set((float)_vertices[index].x(), (float)_vertices[index].y());
         }
     }
 }
@@ -152,12 +152,12 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
 
     bool fillCoordsSphere = _defaultSphereCoordinates.empty();
     int vertexIndex = 0;
-    for (size_t i = 0; i <= _subdivisions; i++)
+    for (size_t i = 0; i <= (size_t)_subdivisions; i++)
     {
-        for (size_t j = 0; j <= _subdivisions; j++)
+        for (size_t j = 0; j <= (size_t)_subdivisions; j++)
         {
-            float x = i * textureSize.width() / (float)_subdivisions;
-            float y = j * textureSize.height() / (float)_subdivisions;
+            float x = (float)i * (float)textureSize.width() / (float)_subdivisions;
+            float y = (float)j * (float)textureSize.height() / (float)_subdivisions;
 
             const double cx = x - center(0);
             const double cy = y - center(1);
@@ -166,20 +166,20 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
 
             if (dist > maxradius)
             {
-                x = center(0) + maxradius * cx / dist;
-                y = center(1) + maxradius * cy / dist;
+                x = (float)(center(0) + maxradius * cx / dist);
+                y = (float)(center(1) + maxradius * cy / dist);
             }
 
 
-            float u = i / (float)_subdivisions;
-            float v = j / (float)_subdivisions;
+            float u = (float)i / (float)_subdivisions;
+            float v = (float)j / (float)_subdivisions;
 
             // Remove Distortion only if sfmData has been updated
             if (isDistortionViewerEnabled() && intrinsic && intrinsic->hasDistortion())
             {
                 const aliceVision::Vec2 undisto_pix(x, y);
                 const aliceVision::Vec2 disto_pix = intrinsic->get_d_pixel(undisto_pix);
-                vertices[vertexIndex].set(disto_pix.x(), disto_pix.y(), u, v);
+                vertices[vertexIndex].set((float)disto_pix.x(), (float)disto_pix.y(), u, v);
             }
 
             // Equirectangular Convertion only if sfmData has been updated
@@ -194,7 +194,7 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
                 }
 
                 // Rotate Panorama if some rotation values exist
-                aliceVision::Vec3 sphereCoordinates(_defaultSphereCoordinates[vertexIndex]);
+                aliceVision::Vec3 sphereCoordinates(_defaultSphereCoordinates[(size_t)vertexIndex]);
                 rotatePanorama(sphereCoordinates);
 
                 // Compute pixel coordinates in the panorama coordinate system
@@ -217,7 +217,7 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
                         _vertexEnabled[i][j - 1] = false;
                     }
                 }
-                vertices[vertexIndex].set(panoramaCoordinates.x(), panoramaCoordinates.y(), u, v);
+                vertices[vertexIndex].set((float)panoramaCoordinates.x(), (float)panoramaCoordinates.y(), u, v);
             }
 
             // Default 
@@ -232,7 +232,7 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
     Q_EMIT verticesChanged();
 }
 
-bool Surface::isPointValid(int i, int j) const
+bool Surface::isPointValid(size_t i, size_t j) const
 {
     // Check if the point and all its neighbours are enabled
     // If not, return false
@@ -250,17 +250,17 @@ bool Surface::isPointValid(int i, int j) const
         if (!_vertexEnabled[i - 1][j - 1]) return false;
     }
 
-    if (i < _subdivisions + 1) {
+    if ((int)i < _subdivisions + 1) {
         if (!_vertexEnabled[i + 1][j]) return false;
         if (j > 0 && !_vertexEnabled[i + 1][j - 1]) return false;
     }
 
-    if (j < _subdivisions + 1) {
+    if ((int)j < _subdivisions + 1) {
         if (!_vertexEnabled[i][j + 1]) return false;
         if (i > 0 && !_vertexEnabled[i - 1][j + 1]) return false;
     }
 
-    if (i < _subdivisions + 1 && j < _subdivisions + 1) {
+    if ((int)i < _subdivisions + 1 && (int)j < _subdivisions + 1) {
         if (!_vertexEnabled[i + 1][j + 1]) return false;
     }
 
@@ -269,9 +269,9 @@ bool Surface::isPointValid(int i, int j) const
 
 void Surface::resetValuesVertexEnabled()
 {
-    for (size_t i = 0; i <= _subdivisions; i++)
+    for (size_t i = 0; i <= (size_t)_subdivisions; i++)
     {
-        for (size_t j = 0; j <= _subdivisions; j++)
+        for (size_t j = 0; j <= (size_t)_subdivisions; j++)
         {
             _vertexEnabled[j][i] = true;
         }
@@ -281,20 +281,20 @@ void Surface::resetValuesVertexEnabled()
 void Surface::computeIndicesGrid(quint16* indices)
 {
     int index = 0;
-    for (int j = 0; j < _subdivisions; j++) {
-        for (int i = 0; i < _subdivisions; i++) {
+    for (size_t j = 0; j < (size_t)_subdivisions; j++) {
+        for (size_t i = 0; i < (size_t)_subdivisions; i++) {
             if (!isPanoramaViewerEnabled() || (isPanoramaViewerEnabled() && isPointValid(i, j)))
             {
-                int topLeft = (i * (_subdivisions + 1)) + j;
+                int topLeft = ((int)i * (_subdivisions + 1)) + (int)j;
                 int topRight = topLeft + 1;
                 int bottomLeft = topLeft + _subdivisions + 1;
                 int bottomRight = bottomLeft + 1;
-                indices[index++] = topLeft;
-                indices[index++] = bottomLeft;
-                indices[index++] = topRight;
-                indices[index++] = topRight;
-                indices[index++] = bottomLeft;
-                indices[index++] = bottomRight;
+                indices[index++] = static_cast<quint16>(topLeft);
+                indices[index++] = static_cast<quint16>(bottomLeft);
+                indices[index++] = static_cast<quint16>(topRight);
+                indices[index++] = static_cast<quint16>(topRight);
+                indices[index++] = static_cast<quint16>(bottomLeft);
+                indices[index++] = static_cast<quint16>(bottomRight);
             }
             else
             {
@@ -308,13 +308,13 @@ void Surface::computeIndicesGrid(quint16* indices)
         }
     }
     _indices.clear();
-    for (size_t i = 0; i < _indexCount; i++)
+    for (size_t i = 0; i < (size_t)_indexCount; i++)
         _indices.append(indices[i]);
 }
 
 void Surface::removeGrid(QSGGeometry* geometryLine)
 {
-    for (size_t i = 0; i < geometryLine->vertexCount(); i++)
+    for (size_t i = 0; i < (size_t)geometryLine->vertexCount(); i++)
     {
         geometryLine->vertexDataAsPoint2D()[i].set(0, 0);
     }
@@ -354,7 +354,7 @@ QPointF Surface::getPrincipalPoint() {
 
     aliceVision::camera::IntrinsicBase* intrinsic = nullptr;
 
-    if (_msfmData && _idView >= 0)
+    if (_msfmData)
     {
         intrinsic = getIntrinsicFromViewId(_idView);
     }
@@ -365,7 +365,7 @@ QPointF Surface::getPrincipalPoint() {
     }
 
     return {ppCorrection.x(), ppCorrection.y()};
-};
+}
 
 
 // VERTICES FUNCTION
@@ -374,7 +374,7 @@ void Surface::fillVertices(QSGGeometry::TexturedPoint2D* vertices)
     _vertices.clear();
     for (int i = 0; i < _vertexCount; i++)
     {
-        QPoint p(vertices[i].x, vertices[i].y);
+        QPoint p((int)vertices[i].x, (int)vertices[i].y);
         _vertices.append(p);
     }
 }
@@ -388,9 +388,9 @@ void Surface::updateSubdivisions(int sub)
     _vertexCount = (_subdivisions + 1) * (_subdivisions + 1);
     _indexCount = _subdivisions * _subdivisions * 6;
 
-    _vertexEnabled.resize(_subdivisions + 1);
-    for (size_t i = 0; i < _subdivisions + 1; i++)
-        _vertexEnabled[i].resize(_subdivisions + 1);
+    _vertexEnabled.resize((size_t)_subdivisions + 1);
+    for (size_t i = 0; i < (size_t)_subdivisions + 1; i++)
+        _vertexEnabled[i].resize((size_t)_subdivisions + 1);
 }
 
 void Surface::setSubdivisions(int newSubdivisions)
@@ -468,7 +468,7 @@ void Surface::setRoll(double rollInDegrees)
 double Surface::getEulerAngleDegrees(double angleRadians)
 {
     double angleDegrees = angleRadians;
-    int power = angleDegrees / M_PI;
+    int power = (int)(angleDegrees / M_PI);
     angleDegrees = fmod(angleDegrees, M_PI) * pow(-1, power);
 
     // Radians to Degrees
@@ -482,43 +482,47 @@ double Surface::getEulerAngleDegrees(double angleRadians)
 // ID VIEW FUNCTION
 void Surface::setIdView(int id)
 {
-    _idView = id;
+    // Handles cases where the sent view ID is unknown or unset (equals  to -1)
+    if (id >= 0)
+        _idView = (unsigned int)id;
+    else
+        _idView = 0;
 }
 
 // MOUSE FUNCTIONS
 bool Surface::isMouseInside(float mx, float my)
 {
-    QPoint P(mx, my);
+    QPointF P(mx, my);
     bool inside = false;
 
     for (int i = 0; i < indexCount(); i += 3)
     {
         if (i + 2 >= _indices.size()) break;
 
-        QPoint A = _vertices[_indices[i]];
-        QPoint B = _vertices[_indices[i + 1]];
-        QPoint C = _vertices[_indices[i + 2]];
+        QPointF A = _vertices[_indices[i]];
+        QPointF B = _vertices[_indices[i + 1]];
+        QPointF C = _vertices[_indices[i + 2]];
 
         // Compute vectors        
-        QPoint v0 = C - A;
-        QPoint v1 = B - A;
-        QPoint v2 = P - A;
+        QPointF v0 = C - A;
+        QPointF v1 = B - A;
+        QPointF v2 = P - A;
 
         // Compute dot products
-        float dot00 = QPoint::dotProduct(v0, v0);
-        float dot01 = QPoint::dotProduct(v0, v1);
-        float dot02 = QPoint::dotProduct(v0, v2);
-        float dot11 = QPoint::dotProduct(v1, v1);
-        float dot12 = QPoint::dotProduct(v1, v2);
+        double dot00 = QPointF::dotProduct(v0, v0);
+        double dot01 = QPointF::dotProduct(v0, v1);
+        double dot02 = QPointF::dotProduct(v0, v2);
+        double dot11 = QPointF::dotProduct(v1, v1);
+        double dot12 = QPointF::dotProduct(v1, v2);
 
         // Compute barycentric coordinates
-        const float dots = (dot00 * dot11 - dot01 * dot01);
+        const double dots = (dot00 * dot11 - dot01 * dot01);
         if (dots == 0)
             continue;
 
-        float invDenom = 1 / dots;
-        float u = (dot11 * dot02 - dot01 * dot12) * invDenom;
-        float v = (dot00 * dot12 - dot01 * dot02) * invDenom;
+        double invDenom = 1 / dots;
+        double u = (dot11 * dot02 - dot01 * dot12) * invDenom;
+        double v = (dot00 * dot12 - dot01 * dot02) * invDenom;
 
         // Check if point is in triangle
         if ((u >= 0) && (v >= 0) && (u + v < 1))
@@ -603,7 +607,7 @@ void Surface::setMSfmData(MSfMData* sfmData)
     Q_EMIT sfmDataChanged();
 }
 
-aliceVision::camera::IntrinsicBase* Surface::getIntrinsicFromViewId(int viewId) const
+aliceVision::camera::IntrinsicBase* Surface::getIntrinsicFromViewId(unsigned int viewId) const
 {
     if(!_msfmData)
     {

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -97,9 +97,11 @@ void Surface::computeGrid(QSGGeometry* geometryLine)
             // Horizontal Lines
             if (i != _subdivisions)
             {
-                geometryLine->vertexDataAsPoint2D()[countPoint++].set(static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
+                geometryLine->vertexDataAsPoint2D()[countPoint++].set(
+                    static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
                 index += _subdivisions + 1;
-                geometryLine->vertexDataAsPoint2D()[countPoint++].set(static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
+                geometryLine->vertexDataAsPoint2D()[countPoint++].set(
+                    static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
                 index -= _subdivisions + 1;
 
                 if (j == _subdivisions)
@@ -110,9 +112,11 @@ void Surface::computeGrid(QSGGeometry* geometryLine)
             }
 
             // Vertical Lines
-            geometryLine->vertexDataAsPoint2D()[countPoint++].set(static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
+            geometryLine->vertexDataAsPoint2D()[countPoint++].set(
+                static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
             index++;
-            geometryLine->vertexDataAsPoint2D()[countPoint++].set(static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
+            geometryLine->vertexDataAsPoint2D()[countPoint++].set(
+                static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
         }
     }
 }
@@ -220,7 +224,8 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
                         _vertexEnabled[i][j - 1] = false;
                     }
                 }
-                vertices[vertexIndex].set(static_cast<float>(panoramaCoordinates.x()), static_cast<float>(panoramaCoordinates.y()), u, v);
+                vertices[vertexIndex].set(
+                    static_cast<float>(panoramaCoordinates.x()), static_cast<float>(panoramaCoordinates.y()), u, v);
             }
 
             // Default

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -491,7 +491,7 @@ bool Surface::isMouseInside(float mx, float my)
     QPoint P(mx, my);
     bool inside = false;
 
-    for (size_t i = 0; i < indexCount(); i += 3)
+    for (int i = 0; i < indexCount(); i += 3)
     {
         if (i + 2 >= _indices.size()) break;
 

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -66,7 +66,7 @@ void Surface::computeGrid(QSGGeometry::TexturedPoint2D* vertices, quint16* indic
             Q_EMIT verticesChanged();
             _needToUseIntrinsic = false;
         }
-        else 
+        else
         {
             verticesComputed = false;
         }
@@ -77,7 +77,7 @@ void Surface::computeGrid(QSGGeometry::TexturedPoint2D* vertices, quint16* indic
         computeVerticesGrid(vertices, textureSize, nullptr);
         setVerticesChanged(false);
     }
-        
+
     computeIndicesGrid(indices);
 }
 
@@ -117,7 +117,7 @@ void Surface::computeGrid(QSGGeometry* geometryLine)
     }
 }
 
-void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize textureSize, 
+void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize textureSize,
     aliceVision::camera::IntrinsicBase* intrinsic, int downscaleLevel)
 {
     // Retrieve pose if Panorama Viewer is enable
@@ -141,14 +141,14 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
     aliceVision::camera::EquiDistant* eqcam = dynamic_cast<aliceVision::camera::EquiDistant*>(intrinsic);
     aliceVision::Vec2 center = {0, 0};
     double radius = std::numeric_limits<double>::max();
-    
+
     if (eqcam)
     {
         center = { eqcam->getCircleCenterX(), eqcam->getCircleCenterY() };
         radius = eqcam->getCircleRadius();
     }
-    
-    
+
+
 
     bool fillCoordsSphere = _defaultSphereCoordinates.empty();
     int vertexIndex = 0;
@@ -202,7 +202,7 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
 
                 // Compute pixel coordinates in the panorama coordinate system
                 aliceVision::Vec2 panoramaCoordinates = toEquirectangular(sphereCoordinates, _panoramaWidth, _panoramaHeight);
-                    
+
                 // If image is on the seem
                 if (vertexIndex > 0 && j > 0)
                 {
@@ -223,7 +223,7 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
                 vertices[vertexIndex].set(static_cast<float>(panoramaCoordinates.x()), static_cast<float>(panoramaCoordinates.y()), u, v);
             }
 
-            // Default 
+            // Default
             if (!intrinsic)
             {
                 vertices[vertexIndex].set(x, y, u, v);
@@ -352,7 +352,7 @@ void Surface::setDisplayGrid(bool display)
     Q_EMIT displayGridChanged();
 }
 
-QPointF Surface::getPrincipalPoint() {     
+QPointF Surface::getPrincipalPoint() {
     aliceVision::Vec2 ppCorrection(0.0, 0.0);
 
     aliceVision::camera::IntrinsicBase* intrinsic = nullptr;
@@ -506,7 +506,7 @@ bool Surface::isMouseInside(float mx, float my)
         QPointF B = _vertices[_indices[i + 1]];
         QPointF C = _vertices[_indices[i + 2]];
 
-        // Compute vectors        
+        // Compute vectors
         QPointF v0 = C - A;
         QPointF v1 = B - A;
         QPointF v2 = P - A;

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -152,12 +152,15 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
 
     bool fillCoordsSphere = _defaultSphereCoordinates.empty();
     int vertexIndex = 0;
+    float fSubdivisions = static_cast<float>(_subdivisions);
     for (size_t i = 0; i <= static_cast<size_t>(_subdivisions); i++)
     {
         for (size_t j = 0; j <= static_cast<size_t>(_subdivisions); j++)
         {
-            float x = static_cast<float>(i) * static_cast<float>(textureSize.width()) / static_cast<float>(_subdivisions);
-            float y = static_cast<float>(j) * static_cast<float>(textureSize.height()) / static_cast<float>(_subdivisions);
+            float fI = static_cast<float>(i);
+            float fJ = static_cast<float>(j);
+            float x = fI * static_cast<float>(textureSize.width()) / fSubdivisions;
+            float y = fJ * static_cast<float>(textureSize.height()) / fSubdivisions;
 
             const double cx = x - center(0);
             const double cy = y - center(1);
@@ -171,8 +174,8 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
             }
 
 
-            float u = static_cast<float>(i) / static_cast<float>(_subdivisions);
-            float v = static_cast<float>(j) / static_cast<float>(_subdivisions);
+            const float u = fI / fSubdivisions;
+            const float v = fJ / fSubdivisions;
 
             // Remove Distortion only if sfmData has been updated
             if (isDistortionViewerEnabled() && intrinsic && intrinsic->hasDistortion())

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -97,9 +97,9 @@ void Surface::computeGrid(QSGGeometry* geometryLine)
             // Horizontal Lines
             if (i != _subdivisions)
             {
-                geometryLine->vertexDataAsPoint2D()[countPoint++].set((float)_vertices[index].x(), (float)_vertices[index].y());
+                geometryLine->vertexDataAsPoint2D()[countPoint++].set(static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
                 index += _subdivisions + 1;
-                geometryLine->vertexDataAsPoint2D()[countPoint++].set((float)_vertices[index].x(), (float)_vertices[index].y());
+                geometryLine->vertexDataAsPoint2D()[countPoint++].set(static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
                 index -= _subdivisions + 1;
 
                 if (j == _subdivisions)
@@ -110,9 +110,9 @@ void Surface::computeGrid(QSGGeometry* geometryLine)
             }
 
             // Vertical Lines
-            geometryLine->vertexDataAsPoint2D()[countPoint++].set((float)_vertices[index].x(), (float)_vertices[index].y());
+            geometryLine->vertexDataAsPoint2D()[countPoint++].set(static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
             index++;
-            geometryLine->vertexDataAsPoint2D()[countPoint++].set((float)_vertices[index].x(), (float)_vertices[index].y());
+            geometryLine->vertexDataAsPoint2D()[countPoint++].set(static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
         }
     }
 }
@@ -152,12 +152,12 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
 
     bool fillCoordsSphere = _defaultSphereCoordinates.empty();
     int vertexIndex = 0;
-    for (size_t i = 0; i <= (size_t)_subdivisions; i++)
+    for (size_t i = 0; i <= static_cast<size_t>(_subdivisions); i++)
     {
-        for (size_t j = 0; j <= (size_t)_subdivisions; j++)
+        for (size_t j = 0; j <= static_cast<size_t>(_subdivisions); j++)
         {
-            float x = (float)i * (float)textureSize.width() / (float)_subdivisions;
-            float y = (float)j * (float)textureSize.height() / (float)_subdivisions;
+            float x = static_cast<float>(i) * static_cast<float>(textureSize.width()) / static_cast<float>(_subdivisions);
+            float y = static_cast<float>(j) * static_cast<float>(textureSize.height()) / static_cast<float>(_subdivisions);
 
             const double cx = x - center(0);
             const double cy = y - center(1);
@@ -166,20 +166,20 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
 
             if (dist > maxradius)
             {
-                x = (float)(center(0) + maxradius * cx / dist);
-                y = (float)(center(1) + maxradius * cy / dist);
+                x = static_cast<float>(center(0) + maxradius * cx / dist);
+                y = static_cast<float>(center(1) + maxradius * cy / dist);
             }
 
 
-            float u = (float)i / (float)_subdivisions;
-            float v = (float)j / (float)_subdivisions;
+            float u = static_cast<float>(i) / static_cast<float>(_subdivisions);
+            float v = static_cast<float>(j) / static_cast<float>(_subdivisions);
 
             // Remove Distortion only if sfmData has been updated
             if (isDistortionViewerEnabled() && intrinsic && intrinsic->hasDistortion())
             {
                 const aliceVision::Vec2 undisto_pix(x, y);
                 const aliceVision::Vec2 disto_pix = intrinsic->get_d_pixel(undisto_pix);
-                vertices[vertexIndex].set((float)disto_pix.x(), (float)disto_pix.y(), u, v);
+                vertices[vertexIndex].set(static_cast<float>(disto_pix.x()), static_cast<float>(disto_pix.y()), u, v);
             }
 
             // Equirectangular Convertion only if sfmData has been updated
@@ -194,7 +194,7 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
                 }
 
                 // Rotate Panorama if some rotation values exist
-                aliceVision::Vec3 sphereCoordinates(_defaultSphereCoordinates[(size_t)vertexIndex]);
+                aliceVision::Vec3 sphereCoordinates(_defaultSphereCoordinates[static_cast<size_t>(vertexIndex)]);
                 rotatePanorama(sphereCoordinates);
 
                 // Compute pixel coordinates in the panorama coordinate system
@@ -217,7 +217,7 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
                         _vertexEnabled[i][j - 1] = false;
                     }
                 }
-                vertices[vertexIndex].set((float)panoramaCoordinates.x(), (float)panoramaCoordinates.y(), u, v);
+                vertices[vertexIndex].set(static_cast<float>(panoramaCoordinates.x()), static_cast<float>(panoramaCoordinates.y()), u, v);
             }
 
             // Default 
@@ -250,17 +250,17 @@ bool Surface::isPointValid(size_t i, size_t j) const
         if (!_vertexEnabled[i - 1][j - 1]) return false;
     }
 
-    if ((int)i < _subdivisions + 1) {
+    if (static_cast<int>(i) < _subdivisions + 1) {
         if (!_vertexEnabled[i + 1][j]) return false;
         if (j > 0 && !_vertexEnabled[i + 1][j - 1]) return false;
     }
 
-    if ((int)j < _subdivisions + 1) {
+    if (static_cast<int>(j) < _subdivisions + 1) {
         if (!_vertexEnabled[i][j + 1]) return false;
         if (i > 0 && !_vertexEnabled[i - 1][j + 1]) return false;
     }
 
-    if ((int)i < _subdivisions + 1 && (int)j < _subdivisions + 1) {
+    if (static_cast<int>(i) < _subdivisions + 1 && static_cast<int>(j) < _subdivisions + 1) {
         if (!_vertexEnabled[i + 1][j + 1]) return false;
     }
 
@@ -269,9 +269,9 @@ bool Surface::isPointValid(size_t i, size_t j) const
 
 void Surface::resetValuesVertexEnabled()
 {
-    for (size_t i = 0; i <= (size_t)_subdivisions; i++)
+    for (size_t i = 0; i <= static_cast<size_t>(_subdivisions); i++)
     {
-        for (size_t j = 0; j <= (size_t)_subdivisions; j++)
+        for (size_t j = 0; j <= static_cast<size_t>(_subdivisions); j++)
         {
             _vertexEnabled[j][i] = true;
         }
@@ -281,11 +281,11 @@ void Surface::resetValuesVertexEnabled()
 void Surface::computeIndicesGrid(quint16* indices)
 {
     int index = 0;
-    for (size_t j = 0; j < (size_t)_subdivisions; j++) {
-        for (size_t i = 0; i < (size_t)_subdivisions; i++) {
+    for (size_t j = 0; j < static_cast<size_t>(_subdivisions); j++) {
+        for (size_t i = 0; i < static_cast<size_t>(_subdivisions); i++) {
             if (!isPanoramaViewerEnabled() || (isPanoramaViewerEnabled() && isPointValid(i, j)))
             {
-                int topLeft = ((int)i * (_subdivisions + 1)) + (int)j;
+                int topLeft = (static_cast<int>(i) * (_subdivisions + 1)) + static_cast<int>(j);
                 int topRight = topLeft + 1;
                 int bottomLeft = topLeft + _subdivisions + 1;
                 int bottomRight = bottomLeft + 1;
@@ -308,13 +308,13 @@ void Surface::computeIndicesGrid(quint16* indices)
         }
     }
     _indices.clear();
-    for (size_t i = 0; i < (size_t)_indexCount; i++)
+    for (size_t i = 0; i < static_cast<size_t>(_indexCount); i++)
         _indices.append(indices[i]);
 }
 
 void Surface::removeGrid(QSGGeometry* geometryLine)
 {
-    for (size_t i = 0; i < (size_t)geometryLine->vertexCount(); i++)
+    for (size_t i = 0; i < static_cast<size_t>(geometryLine->vertexCount()); i++)
     {
         geometryLine->vertexDataAsPoint2D()[i].set(0, 0);
     }
@@ -374,7 +374,7 @@ void Surface::fillVertices(QSGGeometry::TexturedPoint2D* vertices)
     _vertices.clear();
     for (int i = 0; i < _vertexCount; i++)
     {
-        QPoint p((int)vertices[i].x, (int)vertices[i].y);
+        QPoint p(static_cast<int>(vertices[i].x), static_cast<int>(vertices[i].y));
         _vertices.append(p);
     }
 }
@@ -388,9 +388,9 @@ void Surface::updateSubdivisions(int sub)
     _vertexCount = (_subdivisions + 1) * (_subdivisions + 1);
     _indexCount = _subdivisions * _subdivisions * 6;
 
-    _vertexEnabled.resize((size_t)_subdivisions + 1);
-    for (size_t i = 0; i < (size_t)_subdivisions + 1; i++)
-        _vertexEnabled[i].resize((size_t)_subdivisions + 1);
+    _vertexEnabled.resize(static_cast<size_t>(_subdivisions) + 1);
+    for (size_t i = 0; i < static_cast<size_t>(_subdivisions) + 1; i++)
+        _vertexEnabled[i].resize(static_cast<size_t>(_subdivisions) + 1);
 }
 
 void Surface::setSubdivisions(int newSubdivisions)
@@ -468,7 +468,7 @@ void Surface::setRoll(double rollInDegrees)
 double Surface::getEulerAngleDegrees(double angleRadians)
 {
     double angleDegrees = angleRadians;
-    int power = (int)(angleDegrees / M_PI);
+    int power = static_cast<int>(angleDegrees / M_PI);
     angleDegrees = fmod(angleDegrees, M_PI) * pow(-1, power);
 
     // Radians to Degrees
@@ -484,7 +484,7 @@ void Surface::setIdView(int id)
 {
     // Handles cases where the sent view ID is unknown or unset (equals  to -1)
     if (id >= 0)
-        _idView = (unsigned int)id;
+        _idView = static_cast<uint>(id);
     else
         _idView = 0;
 }

--- a/src/Surface.hpp
+++ b/src/Surface.hpp
@@ -24,7 +24,7 @@ Q_OBJECT
 	//Q_PROPERTIES
 
 	Q_PROPERTY(bool displayGrid READ getDisplayGrid WRITE setDisplayGrid NOTIFY displayGridChanged)
-	
+
 	Q_PROPERTY(QColor gridColor READ getGridColor WRITE setGridColor NOTIFY gridColorChanged)
 
 	Q_PROPERTY(int gridOpacity READ getGridOpacity WRITE setGridOpacity NOTIFY gridOpacityChanged)
@@ -143,14 +143,13 @@ public:
 	const aliceVision::camera::EquiDistant* getIntrinsicEquiDistant() const;
 
 private:
-
 	aliceVision::camera::IntrinsicBase* getIntrinsicFromViewId(unsigned int viewId) const;
 
 	void computeGrid(QSGGeometry::TexturedPoint2D* vertices, quint16* indices, QSize textureSize, int downscaleLevel = 0);
 
 	void computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize textureSize,
 		aliceVision::camera::IntrinsicBase* intrinsic, int downscaleLevel = 0);
-		
+
 	void computeIndicesGrid(quint16* indices);
 
 	void rotatePanorama(aliceVision::Vec3& coordSphere);

--- a/src/Surface.hpp
+++ b/src/Surface.hpp
@@ -33,7 +33,7 @@ Q_OBJECT
 
 	Q_PROPERTY(qtAliceVision::MSfMData* msfmData READ getMSfmData WRITE setMSfmData NOTIFY sfmDataChanged)
 
-	Q_PROPERTY(EViewerType viewerType WRITE setViewerType NOTIFY viewerTypeChanged);
+	Q_PROPERTY(EViewerType viewerType READ getViewerType WRITE setViewerType NOTIFY viewerTypeChanged);
 
 	Q_PROPERTY(QList<QPoint> vertices READ vertices NOTIFY verticesChanged);
 
@@ -95,7 +95,7 @@ public:
 	// VIEWER TYPE
 	enum class EViewerType : quint8 { DEFAULT = 0, HDR, DISTORTION, PANORAMA };
 	Q_ENUM(EViewerType)
-
+	EViewerType getViewerType() const { return _viewerType; }
 	void setViewerType(EViewerType type);
 	bool isPanoramaViewerEnabled() const;
 	bool isDistortionViewerEnabled() const;

--- a/src/Surface.hpp
+++ b/src/Surface.hpp
@@ -23,25 +23,25 @@ Q_OBJECT
 
 	//Q_PROPERTIES
 
-	Q_PROPERTY(bool displayGrid READ getDisplayGrid WRITE setDisplayGrid NOTIFY displayGridChanged);
+	Q_PROPERTY(bool displayGrid READ getDisplayGrid WRITE setDisplayGrid NOTIFY displayGridChanged)
 	
-	Q_PROPERTY(QColor gridColor READ getGridColor WRITE setGridColor NOTIFY gridColorChanged);
+	Q_PROPERTY(QColor gridColor READ getGridColor WRITE setGridColor NOTIFY gridColorChanged)
 
-	Q_PROPERTY(int gridOpacity READ getGridOpacity WRITE setGridOpacity NOTIFY gridOpacityChanged);
+	Q_PROPERTY(int gridOpacity READ getGridOpacity WRITE setGridOpacity NOTIFY gridOpacityChanged)
 
-	Q_PROPERTY(bool mouseOver READ getMouseOver WRITE setMouseOver NOTIFY mouseOverChanged);
+	Q_PROPERTY(bool mouseOver READ getMouseOver WRITE setMouseOver NOTIFY mouseOverChanged)
 
 	Q_PROPERTY(qtAliceVision::MSfMData* msfmData READ getMSfmData WRITE setMSfmData NOTIFY sfmDataChanged)
 
-	Q_PROPERTY(EViewerType viewerType READ getViewerType WRITE setViewerType NOTIFY viewerTypeChanged);
+	Q_PROPERTY(EViewerType viewerType READ getViewerType WRITE setViewerType NOTIFY viewerTypeChanged)
 
-	Q_PROPERTY(QList<QPoint> vertices READ vertices NOTIFY verticesChanged);
+	Q_PROPERTY(QList<QPoint> vertices READ vertices NOTIFY verticesChanged)
 
-	Q_PROPERTY(int subdivisions READ getSubdivisions WRITE setSubdivisions NOTIFY subdivisionsChanged);
+	Q_PROPERTY(int subdivisions READ getSubdivisions WRITE setSubdivisions NOTIFY subdivisionsChanged)
 
-	Q_PROPERTY(double yaw READ getYaw WRITE setYaw NOTIFY anglesChanged);
-	Q_PROPERTY(double pitch READ getPitch WRITE setPitch NOTIFY anglesChanged);
-	Q_PROPERTY(double roll READ getRoll WRITE setRoll NOTIFY anglesChanged);
+	Q_PROPERTY(double yaw READ getYaw WRITE setYaw NOTIFY anglesChanged)
+	Q_PROPERTY(double pitch READ getPitch WRITE setPitch NOTIFY anglesChanged)
+	Q_PROPERTY(double roll READ getRoll WRITE setRoll NOTIFY anglesChanged)
 
 
 public:
@@ -144,7 +144,7 @@ public:
 
 private:
 
-	aliceVision::camera::IntrinsicBase* getIntrinsicFromViewId(int viewId) const;
+	aliceVision::camera::IntrinsicBase* getIntrinsicFromViewId(unsigned int viewId) const;
 
 	void computeGrid(QSGGeometry::TexturedPoint2D* vertices, quint16* indices, QSize textureSize, int downscaleLevel = 0);
 
@@ -157,7 +157,7 @@ private:
 
 	void updateSubdivisions(int sub);
 
-	bool isPointValid(int i, int j) const;
+	bool isPointValid(std::size_t i, std::size_t j) const;
 
 	void resetValuesVertexEnabled();
 

--- a/src/depthMapEntity/CMakeLists.txt
+++ b/src/depthMapEntity/CMakeLists.txt
@@ -25,6 +25,12 @@ find_package(OpenImageIO REQUIRED)
 # Target properties
 add_library(depthMapEntityPlugin SHARED ${PLUGIN_SOURCES} ${PLUGIN_HEADERS})
 
+if(MSVC)
+    target_compile_options(depthMapEntityPlugin PUBLIC /W4)
+else()
+    target_compile_options(depthMapEntityPlugin PUBLIC -Wall -Wextra -Wconversion -Wsign-conversion -Wshadow -Wpedantic)
+endif()
+
 target_include_directories(depthMapEntityPlugin 
     PUBLIC 
     ${OPENIMAGEIO_INCLUDE_DIRS}

--- a/src/depthMapEntity/DepthMapEntity.cpp
+++ b/src/depthMapEntity/DepthMapEntity.cpp
@@ -319,7 +319,7 @@ void DepthMapEntity::loadDepthMap()
             Point3d p = CArr + (iCamArr * Point2d((double)x, (double)y)).normalize() * depthValue;
             Vec3f position(p.x, -p.y, -p.z);
 
-            indexPerPixel[y * depthMap.Width() + x] = positions.size();
+            indexPerPixel[y * depthMap.Width() + x] = (int)positions.size();
             positions.push_back(position);
 
             if(validSimMap)
@@ -393,11 +393,11 @@ void DepthMapEntity::loadDepthMap()
     }
 
     QBuffer* vertexBuffer = new QBuffer(QBuffer::VertexBuffer);
-    QByteArray trianglesData((const char*)&triangles[0], triangles.size() * sizeof(Vec3f));
+    QByteArray trianglesData((const char*)&triangles[0], (int)triangles.size() * sizeof(Vec3f));
     vertexBuffer->setData(trianglesData);
 
     QBuffer* normalBuffer = new QBuffer(QBuffer::VertexBuffer);
-    QByteArray normalsData((const char*)&normals[0], normals.size() * sizeof(Vec3f));
+    QByteArray normalsData((const char*)&normals[0], (int)normals.size() * sizeof(Vec3f));
     normalBuffer->setData(normalsData);
 
     QAttribute* positionAttribute = new QAttribute(this);
@@ -408,7 +408,7 @@ void DepthMapEntity::loadDepthMap()
     positionAttribute->setDataSize(3);
     positionAttribute->setByteOffset(0);
     positionAttribute->setByteStride(sizeof(Vec3f));
-    positionAttribute->setCount(triangles.size());
+    positionAttribute->setCount((uint)triangles.size());
 
     QAttribute* normalAttribute = new QAttribute(this);
     normalAttribute->setName(QAttribute::defaultNormalAttributeName());
@@ -418,7 +418,7 @@ void DepthMapEntity::loadDepthMap()
     normalAttribute->setDataSize(3);
     normalAttribute->setByteOffset(0);
     normalAttribute->setByteStride(sizeof(Vec3f));
-    normalAttribute->setCount(normals.size());
+    normalAttribute->setCount((uint)normals.size());
 
     customGeometry->addAttribute(positionAttribute);
     customGeometry->addAttribute(normalAttribute);
@@ -434,7 +434,7 @@ void DepthMapEntity::loadDepthMap()
 
     // read color data
     QBuffer* colorDataBuffer = new QBuffer(QBuffer::VertexBuffer);
-    QByteArray colorData((const char*)colorsFlat[0].data(), colorsFlat.size() * 3 * sizeof(float));
+    QByteArray colorData((const char*)colorsFlat[0].data(), (int)colorsFlat.size() * 3 * sizeof(float));
     colorDataBuffer->setData(colorData);
 
     QAttribute* colorAttribute = new QAttribute;
@@ -446,7 +446,7 @@ void DepthMapEntity::loadDepthMap()
     colorAttribute->setDataSize(3);
     colorAttribute->setByteOffset(0);
     colorAttribute->setByteStride(3 * sizeof(float));
-    colorAttribute->setCount(colorsFlat.size());
+    colorAttribute->setCount((uint)colorsFlat.size());
     customGeometry->addAttribute(colorAttribute);
 
     // create the geometry renderer

--- a/src/depthMapEntity/DepthMapEntity.cpp
+++ b/src/depthMapEntity/DepthMapEntity.cpp
@@ -51,7 +51,7 @@ void DepthMapEntity::setSource(const QUrl& value)
         _status = DepthMapEntity::Error;
         return;
     }
-    
+
     _source = value;
 
     QFileInfo fileInfo = QFileInfo(_source.path());
@@ -290,7 +290,7 @@ void DepthMapEntity::loadDepthMap()
         qDebug() << "[DepthMapEntity] load sim map: " << _simMapSource.toLocalFile();
         image::readImage(simMapPath, simMap, image::EImageColorSpace::LINEAR);
     }
-    else 
+    else
     {
         qDebug() << "[DepthMapEntity] failed to find associated sim map";
     }
@@ -433,7 +433,7 @@ void DepthMapEntity::loadDepthMap()
     customGeometry->addAttribute(positionAttribute);
     customGeometry->addAttribute(normalAttribute);
     // customGeometry->setBoundingVolumePositionAttribute(positionAttribute);
-        
+
     // Duplicate colors as we cannot use indexes!
     std::vector<image::RGBfColor> colorsFlat;
     colorsFlat.reserve(trianglesIndexes.size());
@@ -462,9 +462,9 @@ void DepthMapEntity::loadDepthMap()
     // create the geometry renderer
     _meshRenderer = new QGeometryRenderer;
     _meshRenderer->setGeometry(customGeometry);
-    
+
     _status = DepthMapEntity::Ready;
-    
+
     // add components
     addComponent(_meshRenderer);
     updateMaterial();

--- a/src/depthMapEntity/DepthMapEntity.cpp
+++ b/src/depthMapEntity/DepthMapEntity.cpp
@@ -354,27 +354,34 @@ void DepthMapEntity::loadDepthMap()
             int pixelIndexB = indexPerPixel[static_cast<std::size_t>((y + 1) * depthMap.Width() + x)];
             int pixelIndexC = indexPerPixel[static_cast<std::size_t>((y + 1) * depthMap.Width() + x + 1)];
             int pixelIndexD = indexPerPixel[static_cast<std::size_t>(y * depthMap.Width() + x + 1)];
+
+            // Cast indices to std::size_t once for readability
+            std::size_t sPixelIndexA = static_cast<std::size_t>(pixelIndexA);
+            std::size_t sPixelIndexB = static_cast<std::size_t>(pixelIndexB);
+            std::size_t sPixelIndexC = static_cast<std::size_t>(pixelIndexC);
+            std::size_t sPixelIndexD = static_cast<std::size_t>(pixelIndexD);
+
             if(pixelIndexA != -1 &&
                 pixelIndexB != -1 &&
                 pixelIndexC != -1 &&
-                validTriangleRatio(positions[static_cast<std::size_t>(pixelIndexA)],
-                                    positions[static_cast<std::size_t>(pixelIndexB)],
-                                    positions[static_cast<std::size_t>(pixelIndexC)]))
+                validTriangleRatio(positions[sPixelIndexA],
+                                    positions[sPixelIndexB],
+                                    positions[sPixelIndexC]))
             {
-                trianglesIndexes.push_back(static_cast<std::size_t>(pixelIndexA));
-                trianglesIndexes.push_back(static_cast<std::size_t>(pixelIndexB));
-                trianglesIndexes.push_back(static_cast<std::size_t>(pixelIndexC));
+                trianglesIndexes.push_back(sPixelIndexA);
+                trianglesIndexes.push_back(sPixelIndexB);
+                trianglesIndexes.push_back(sPixelIndexC);
             }
             if(pixelIndexC != -1 &&
                 pixelIndexD != -1 &&
                 pixelIndexA != -1 &&
-                validTriangleRatio(positions[static_cast<std::size_t>(pixelIndexC)],
-                                    positions[static_cast<std::size_t>(pixelIndexD)],
-                                    positions[static_cast<std::size_t>(pixelIndexA)]))
+                validTriangleRatio(positions[sPixelIndexC],
+                                    positions[sPixelIndexD],
+                                    positions[sPixelIndexA]))
             {
-                trianglesIndexes.push_back(static_cast<std::size_t>(pixelIndexC));
-                trianglesIndexes.push_back(static_cast<std::size_t>(pixelIndexD));
-                trianglesIndexes.push_back(static_cast<std::size_t>(pixelIndexA));
+                trianglesIndexes.push_back(sPixelIndexC);
+                trianglesIndexes.push_back(sPixelIndexD);
+                trianglesIndexes.push_back(sPixelIndexA);
             }
         }
     }

--- a/src/depthMapEntity/DepthMapEntity.cpp
+++ b/src/depthMapEntity/DepthMapEntity.cpp
@@ -301,12 +301,11 @@ void DepthMapEntity::loadDepthMap()
 
     qDebug() << "[DepthMapEntity] computing positions and colors for point cloud";
 
-    std::vector<int> indexPerPixel(depthMap.Width() * depthMap.Height(), -1);
+    std::vector<int> indexPerPixel((std::size_t)(depthMap.Width() * depthMap.Height()), -1);
     std::vector<Vec3f> positions;
     std::vector<image::RGBfColor> colors;
 
-    oiio::ImageBufAlgo::PixelStats stats;
-    oiio::ImageBufAlgo::computePixelStats(stats, inBuf);
+    oiio::ImageBufAlgo::PixelStats stats = oiio::ImageBufAlgo::computePixelStats(inBuf);
 
     for(int y = 0; y < depthMap.Height(); ++y)
     {
@@ -317,9 +316,9 @@ void DepthMapEntity::loadDepthMap()
                 continue;
 
             Point3d p = CArr + (iCamArr * Point2d((double)x, (double)y)).normalize() * depthValue;
-            Vec3f position(p.x, -p.y, -p.z);
+            Vec3f position((float)p.x, (float)-p.y, (float)-p.z);
 
-            indexPerPixel[y * depthMap.Width() + x] = (int)positions.size();
+            indexPerPixel[(std::size_t)(y * depthMap.Width() + x)] = (int)positions.size();
             positions.push_back(position);
 
             if(validSimMap)
@@ -345,33 +344,37 @@ void DepthMapEntity::loadDepthMap()
     QGeometry* customGeometry = new QGeometry;
 
     // vertices buffer
-    std::vector<int> trianglesIndexes;
+    std::vector<std::size_t> trianglesIndexes;
     trianglesIndexes.reserve(2*3*positions.size());
     for(int y = 0; y < depthMap.Height()-1; ++y)
     {
         for(int x = 0; x < depthMap.Width()-1; ++x)
         {
-            int pixelIndexA = indexPerPixel[y * depthMap.Width() + x];
-            int pixelIndexB = indexPerPixel[(y + 1) * depthMap.Width() + x];
-            int pixelIndexC = indexPerPixel[(y + 1) * depthMap.Width() + x + 1];
-            int pixelIndexD = indexPerPixel[y * depthMap.Width() + x + 1];
+            int pixelIndexA = indexPerPixel[(std::size_t)(y * depthMap.Width() + x)];
+            int pixelIndexB = indexPerPixel[(std::size_t)((y + 1) * depthMap.Width() + x)];
+            int pixelIndexC = indexPerPixel[(std::size_t)((y + 1) * depthMap.Width() + x + 1)];
+            int pixelIndexD = indexPerPixel[(std::size_t)(y * depthMap.Width() + x + 1)];
             if(pixelIndexA != -1 &&
                 pixelIndexB != -1 &&
                 pixelIndexC != -1 &&
-                validTriangleRatio(positions[pixelIndexA], positions[pixelIndexB], positions[pixelIndexC]))
+                validTriangleRatio(positions[(std::size_t)pixelIndexA],
+                                    positions[(std::size_t)pixelIndexB],
+                                    positions[(std::size_t)pixelIndexC]))
             {
-                trianglesIndexes.push_back(pixelIndexA);
-                trianglesIndexes.push_back(pixelIndexB);
-                trianglesIndexes.push_back(pixelIndexC);
+                trianglesIndexes.push_back((std::size_t)pixelIndexA);
+                trianglesIndexes.push_back((std::size_t)pixelIndexB);
+                trianglesIndexes.push_back((std::size_t)pixelIndexC);
             }
             if(pixelIndexC != -1 &&
                 pixelIndexD != -1 &&
                 pixelIndexA != -1 &&
-                validTriangleRatio(positions[pixelIndexC], positions[pixelIndexD], positions[pixelIndexA]))
+                validTriangleRatio(positions[(std::size_t)pixelIndexC],
+                                    positions[(std::size_t)pixelIndexD],
+                                    positions[(std::size_t)pixelIndexA]))
             {
-                trianglesIndexes.push_back(pixelIndexC);
-                trianglesIndexes.push_back(pixelIndexD);
-                trianglesIndexes.push_back(pixelIndexA);
+                trianglesIndexes.push_back((std::size_t)pixelIndexC);
+                trianglesIndexes.push_back((std::size_t)pixelIndexD);
+                trianglesIndexes.push_back((std::size_t)pixelIndexA);
             }
         }
     }
@@ -379,33 +382,33 @@ void DepthMapEntity::loadDepthMap()
 
     std::vector<Vec3f> triangles;
     triangles.resize(trianglesIndexes.size());
-    for(int i = 0; i < trianglesIndexes.size(); ++i)
+    for(std::size_t i = 0; i < trianglesIndexes.size(); ++i)
     {
         triangles[i] = positions[trianglesIndexes[i]];
     }
     std::vector<Vec3f> normals;
     normals.resize(triangles.size());
-    for(int i = 0; i < trianglesIndexes.size(); i+=3)
+    for(std::size_t i = 0; i < trianglesIndexes.size(); i+=3)
     {
         Vec3f normal = (triangles[i+1]-triangles[i]).cross(triangles[i+2]-triangles[i]);
-        for(int t = 0; t < 3; ++t)
+        for(std::size_t t = 0; t < 3; ++t)
             normals[i+t] = normal;
     }
 
-    QBuffer* vertexBuffer = new QBuffer(QBuffer::VertexBuffer);
-    QByteArray trianglesData((const char*)&triangles[0], (int)triangles.size() * sizeof(Vec3f));
+    QBuffer* vertexBuffer = new QBuffer;
+    QByteArray trianglesData((const char*)&triangles[0], (int)(triangles.size() * sizeof(Vec3f)));
     vertexBuffer->setData(trianglesData);
 
-    QBuffer* normalBuffer = new QBuffer(QBuffer::VertexBuffer);
-    QByteArray normalsData((const char*)&normals[0], (int)normals.size() * sizeof(Vec3f));
+    QBuffer* normalBuffer = new QBuffer;
+    QByteArray normalsData((const char*)&normals[0], (int)(normals.size() * sizeof(Vec3f)));
     normalBuffer->setData(normalsData);
 
     QAttribute* positionAttribute = new QAttribute(this);
     positionAttribute->setName(QAttribute::defaultPositionAttributeName());
     positionAttribute->setAttributeType(QAttribute::VertexAttribute);
     positionAttribute->setBuffer(vertexBuffer);
-    positionAttribute->setDataType(QAttribute::Float);
-    positionAttribute->setDataSize(3);
+    positionAttribute->setVertexBaseType(QAttribute::Float);
+    positionAttribute->setVertexSize(3);
     positionAttribute->setByteOffset(0);
     positionAttribute->setByteStride(sizeof(Vec3f));
     positionAttribute->setCount((uint)triangles.size());
@@ -414,8 +417,8 @@ void DepthMapEntity::loadDepthMap()
     normalAttribute->setName(QAttribute::defaultNormalAttributeName());
     normalAttribute->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
     normalAttribute->setBuffer(normalBuffer);
-    normalAttribute->setDataType(QAttribute::Float);
-    normalAttribute->setDataSize(3);
+    normalAttribute->setVertexBaseType(QAttribute::Float);
+    normalAttribute->setVertexSize(3);
     normalAttribute->setByteOffset(0);
     normalAttribute->setByteStride(sizeof(Vec3f));
     normalAttribute->setCount((uint)normals.size());
@@ -427,14 +430,14 @@ void DepthMapEntity::loadDepthMap()
     // Duplicate colors as we cannot use indexes!
     std::vector<image::RGBfColor> colorsFlat;
     colorsFlat.reserve(trianglesIndexes.size());
-    for(int i = 0; i < trianglesIndexes.size(); ++i)
+    for(std::size_t i = 0; i < trianglesIndexes.size(); ++i)
     {
         colorsFlat.push_back(colors[trianglesIndexes[i]]);
     }
 
     // read color data
-    QBuffer* colorDataBuffer = new QBuffer(QBuffer::VertexBuffer);
-    QByteArray colorData((const char*)colorsFlat[0].data(), (int)colorsFlat.size() * 3 * sizeof(float));
+    QBuffer* colorDataBuffer = new QBuffer;
+    QByteArray colorData((const char*)colorsFlat[0].data(), (int)(colorsFlat.size() * 3 * sizeof(float)));
     colorDataBuffer->setData(colorData);
 
     QAttribute* colorAttribute = new QAttribute;
@@ -442,8 +445,8 @@ void DepthMapEntity::loadDepthMap()
     colorAttribute->setName(Qt3DRender::QAttribute::defaultColorAttributeName());
     colorAttribute->setAttributeType(QAttribute::VertexAttribute);
     colorAttribute->setBuffer(colorDataBuffer);
-    colorAttribute->setDataType(QAttribute::Float);
-    colorAttribute->setDataSize(3);
+    colorAttribute->setVertexBaseType(QAttribute::Float);
+    colorAttribute->setVertexSize(3);
     colorAttribute->setByteOffset(0);
     colorAttribute->setByteStride(3 * sizeof(float));
     colorAttribute->setCount((uint)colorsFlat.size());

--- a/src/depthMapEntity/DepthMapEntity.cpp
+++ b/src/depthMapEntity/DepthMapEntity.cpp
@@ -268,7 +268,9 @@ void DepthMapEntity::loadDepthMap()
     }
 
     Matrix3x3 iCamArr;
-    const oiio::ParamValue * icParam = inSpec.find_attribute("AliceVision:iCamArr", oiio::TypeDesc(oiio::TypeDesc::DOUBLE, oiio::TypeDesc::MATRIX33));
+    const oiio::ParamValue * icParam = inSpec.find_attribute("AliceVision:iCamArr",
+        oiio::TypeDesc(oiio::TypeDesc::DOUBLE, oiio::TypeDesc::MATRIX33));
+
     if(icParam)
     {
         qDebug() << "[DepthMapEntity] iCamArr: " << icParam->nvalues();
@@ -403,11 +405,13 @@ void DepthMapEntity::loadDepthMap()
     }
 
     QBuffer* vertexBuffer = new QBuffer;
-    QByteArray trianglesData(reinterpret_cast<const char*>(&triangles[0]), static_cast<int>(triangles.size() * sizeof(Vec3f)));
+    QByteArray trianglesData(reinterpret_cast<const char*>(&triangles[0]),
+                             static_cast<int>(triangles.size() * sizeof(Vec3f)));
     vertexBuffer->setData(trianglesData);
 
     QBuffer* normalBuffer = new QBuffer;
-    QByteArray normalsData(reinterpret_cast<const char*>(&normals[0]), static_cast<int>(normals.size() * sizeof(Vec3f)));
+    QByteArray normalsData(reinterpret_cast<const char*>(&normals[0]),
+                           static_cast<int>(normals.size() * sizeof(Vec3f)));
     normalBuffer->setData(normalsData);
 
     QAttribute* positionAttribute = new QAttribute(this);
@@ -444,11 +448,13 @@ void DepthMapEntity::loadDepthMap()
 
     // read color data
     QBuffer* colorDataBuffer = new QBuffer;
-    QByteArray colorData(reinterpret_cast<const char*>(colorsFlat[0].data()), static_cast<int>(colorsFlat.size() * 3 * sizeof(float)));
+    QByteArray colorData(reinterpret_cast<const char*>(colorsFlat[0].data()),
+                         static_cast<int>(colorsFlat.size() * 3 * sizeof(float)));
     colorDataBuffer->setData(colorData);
 
     QAttribute* colorAttribute = new QAttribute;
-    qDebug() << "[DepthMapEntity] Qt3DRender::QAttribute::defaultColorAttributeName(): " << Qt3DRender::QAttribute::defaultColorAttributeName();
+    qDebug() << "[DepthMapEntity] Qt3DRender::QAttribute::defaultColorAttributeName(): "
+             << Qt3DRender::QAttribute::defaultColorAttributeName();
     colorAttribute->setName(Qt3DRender::QAttribute::defaultColorAttributeName());
     colorAttribute->setAttributeType(QAttribute::VertexAttribute);
     colorAttribute->setBuffer(colorDataBuffer);

--- a/src/depthMapEntity/DepthMapEntity.cpp
+++ b/src/depthMapEntity/DepthMapEntity.cpp
@@ -258,7 +258,7 @@ void DepthMapEntity::loadDepthMap()
     if(cParam)
     {
         qDebug() << "[DepthMapEntity] CArr: " << cParam->nvalues();
-        std::copy_n((const double*)cParam->data(), 3, CArr.m);
+        std::copy_n(static_cast<const double*>(cParam->data()), 3, CArr.m);
     }
     else
     {
@@ -272,7 +272,7 @@ void DepthMapEntity::loadDepthMap()
     if(icParam)
     {
         qDebug() << "[DepthMapEntity] iCamArr: " << icParam->nvalues();
-        std::copy_n((const double*)icParam->data(), 9, iCamArr.m);
+        std::copy_n(static_cast<const double*>(icParam->data()), 9, iCamArr.m);
     }
     else
     {
@@ -301,7 +301,7 @@ void DepthMapEntity::loadDepthMap()
 
     qDebug() << "[DepthMapEntity] computing positions and colors for point cloud";
 
-    std::vector<int> indexPerPixel((std::size_t)(depthMap.Width() * depthMap.Height()), -1);
+    std::vector<int> indexPerPixel(static_cast<std::size_t>(depthMap.Width() * depthMap.Height()), -1);
     std::vector<Vec3f> positions;
     std::vector<image::RGBfColor> colors;
 
@@ -315,10 +315,10 @@ void DepthMapEntity::loadDepthMap()
             if(!std::isfinite(depthValue) || depthValue <= 0.f)
                 continue;
 
-            Point3d p = CArr + (iCamArr * Point2d((double)x, (double)y)).normalize() * depthValue;
-            Vec3f position((float)p.x, (float)-p.y, (float)-p.z);
+            Point3d p = CArr + (iCamArr * Point2d(static_cast<double>(x), static_cast<double>(y))).normalize() * depthValue;
+            Vec3f position(static_cast<float>(p.x), static_cast<float>(-p.y), static_cast<float>(-p.z));
 
-            indexPerPixel[(std::size_t)(y * depthMap.Width() + x)] = (int)positions.size();
+            indexPerPixel[static_cast<std::size_t>(y * depthMap.Width() + x)] = static_cast<int>(positions.size());
             positions.push_back(position);
 
             if(validSimMap)
@@ -350,31 +350,31 @@ void DepthMapEntity::loadDepthMap()
     {
         for(int x = 0; x < depthMap.Width()-1; ++x)
         {
-            int pixelIndexA = indexPerPixel[(std::size_t)(y * depthMap.Width() + x)];
-            int pixelIndexB = indexPerPixel[(std::size_t)((y + 1) * depthMap.Width() + x)];
-            int pixelIndexC = indexPerPixel[(std::size_t)((y + 1) * depthMap.Width() + x + 1)];
-            int pixelIndexD = indexPerPixel[(std::size_t)(y * depthMap.Width() + x + 1)];
+            int pixelIndexA = indexPerPixel[static_cast<std::size_t>(y * depthMap.Width() + x)];
+            int pixelIndexB = indexPerPixel[static_cast<std::size_t>((y + 1) * depthMap.Width() + x)];
+            int pixelIndexC = indexPerPixel[static_cast<std::size_t>((y + 1) * depthMap.Width() + x + 1)];
+            int pixelIndexD = indexPerPixel[static_cast<std::size_t>(y * depthMap.Width() + x + 1)];
             if(pixelIndexA != -1 &&
                 pixelIndexB != -1 &&
                 pixelIndexC != -1 &&
-                validTriangleRatio(positions[(std::size_t)pixelIndexA],
-                                    positions[(std::size_t)pixelIndexB],
-                                    positions[(std::size_t)pixelIndexC]))
+                validTriangleRatio(positions[static_cast<std::size_t>(pixelIndexA)],
+                                    positions[static_cast<std::size_t>(pixelIndexB)],
+                                    positions[static_cast<std::size_t>(pixelIndexC)]))
             {
-                trianglesIndexes.push_back((std::size_t)pixelIndexA);
-                trianglesIndexes.push_back((std::size_t)pixelIndexB);
-                trianglesIndexes.push_back((std::size_t)pixelIndexC);
+                trianglesIndexes.push_back(static_cast<std::size_t>(pixelIndexA));
+                trianglesIndexes.push_back(static_cast<std::size_t>(pixelIndexB));
+                trianglesIndexes.push_back(static_cast<std::size_t>(pixelIndexC));
             }
             if(pixelIndexC != -1 &&
                 pixelIndexD != -1 &&
                 pixelIndexA != -1 &&
-                validTriangleRatio(positions[(std::size_t)pixelIndexC],
-                                    positions[(std::size_t)pixelIndexD],
-                                    positions[(std::size_t)pixelIndexA]))
+                validTriangleRatio(positions[static_cast<std::size_t>(pixelIndexC)],
+                                    positions[static_cast<std::size_t>(pixelIndexD)],
+                                    positions[static_cast<std::size_t>(pixelIndexA)]))
             {
-                trianglesIndexes.push_back((std::size_t)pixelIndexC);
-                trianglesIndexes.push_back((std::size_t)pixelIndexD);
-                trianglesIndexes.push_back((std::size_t)pixelIndexA);
+                trianglesIndexes.push_back(static_cast<std::size_t>(pixelIndexC));
+                trianglesIndexes.push_back(static_cast<std::size_t>(pixelIndexD));
+                trianglesIndexes.push_back(static_cast<std::size_t>(pixelIndexA));
             }
         }
     }
@@ -396,11 +396,11 @@ void DepthMapEntity::loadDepthMap()
     }
 
     QBuffer* vertexBuffer = new QBuffer;
-    QByteArray trianglesData((const char*)&triangles[0], (int)(triangles.size() * sizeof(Vec3f)));
+    QByteArray trianglesData(reinterpret_cast<const char*>(&triangles[0]), static_cast<int>(triangles.size() * sizeof(Vec3f)));
     vertexBuffer->setData(trianglesData);
 
     QBuffer* normalBuffer = new QBuffer;
-    QByteArray normalsData((const char*)&normals[0], (int)(normals.size() * sizeof(Vec3f)));
+    QByteArray normalsData(reinterpret_cast<const char*>(&normals[0]), static_cast<int>(normals.size() * sizeof(Vec3f)));
     normalBuffer->setData(normalsData);
 
     QAttribute* positionAttribute = new QAttribute(this);
@@ -411,7 +411,7 @@ void DepthMapEntity::loadDepthMap()
     positionAttribute->setVertexSize(3);
     positionAttribute->setByteOffset(0);
     positionAttribute->setByteStride(sizeof(Vec3f));
-    positionAttribute->setCount((uint)triangles.size());
+    positionAttribute->setCount(static_cast<uint>(triangles.size()));
 
     QAttribute* normalAttribute = new QAttribute(this);
     normalAttribute->setName(QAttribute::defaultNormalAttributeName());
@@ -421,7 +421,7 @@ void DepthMapEntity::loadDepthMap()
     normalAttribute->setVertexSize(3);
     normalAttribute->setByteOffset(0);
     normalAttribute->setByteStride(sizeof(Vec3f));
-    normalAttribute->setCount((uint)normals.size());
+    normalAttribute->setCount(static_cast<uint>(normals.size()));
 
     customGeometry->addAttribute(positionAttribute);
     customGeometry->addAttribute(normalAttribute);
@@ -437,7 +437,7 @@ void DepthMapEntity::loadDepthMap()
 
     // read color data
     QBuffer* colorDataBuffer = new QBuffer;
-    QByteArray colorData((const char*)colorsFlat[0].data(), (int)(colorsFlat.size() * 3 * sizeof(float)));
+    QByteArray colorData(reinterpret_cast<const char*>(colorsFlat[0].data()), static_cast<int>(colorsFlat.size() * 3 * sizeof(float)));
     colorDataBuffer->setData(colorData);
 
     QAttribute* colorAttribute = new QAttribute;
@@ -449,7 +449,7 @@ void DepthMapEntity::loadDepthMap()
     colorAttribute->setVertexSize(3);
     colorAttribute->setByteOffset(0);
     colorAttribute->setByteStride(3 * sizeof(float));
-    colorAttribute->setCount((uint)colorsFlat.size());
+    colorAttribute->setCount(static_cast<uint>(colorsFlat.size()));
     customGeometry->addAttribute(colorAttribute);
 
     // create the geometry renderer

--- a/src/depthMapEntity/DepthMapEntity.hpp
+++ b/src/depthMapEntity/DepthMapEntity.hpp
@@ -18,11 +18,11 @@ class DepthMapEntity : public Qt3DCore::QEntity
     Q_OBJECT
     Q_ENUMS(DisplayMode)
 
-    Q_PROPERTY(QUrl source READ source WRITE setSource NOTIFY sourceChanged);
+    Q_PROPERTY(QUrl source READ source WRITE setSource NOTIFY sourceChanged)
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
-    Q_PROPERTY(DisplayMode displayMode READ displayMode WRITE setDisplayMode NOTIFY displayModeChanged);
-    Q_PROPERTY(bool displayColor READ displayColor WRITE setDisplayColor NOTIFY displayColorChanged);
-    Q_PROPERTY(float pointSize READ pointSize WRITE setPointSize NOTIFY pointSizeChanged);
+    Q_PROPERTY(DisplayMode displayMode READ displayMode WRITE setDisplayMode NOTIFY displayModeChanged)
+    Q_PROPERTY(bool displayColor READ displayColor WRITE setDisplayColor NOTIFY displayColorChanged)
+    Q_PROPERTY(float pointSize READ pointSize WRITE setPointSize NOTIFY pointSizeChanged)
 
 public:
 

--- a/src/depthMapEntity/DepthMapEntity.hpp
+++ b/src/depthMapEntity/DepthMapEntity.hpp
@@ -25,9 +25,8 @@ class DepthMapEntity : public Qt3DCore::QEntity
     Q_PROPERTY(float pointSize READ pointSize WRITE setPointSize NOTIFY pointSizeChanged)
 
 public:
-
     // Identical to SceneLoader.Status
-    enum Status { 
+    enum Status {
         None = 0,
         Loading,
         Ready,
@@ -50,11 +49,11 @@ public:
 
     Status status() const { return _status; }
 
-    void setStatus(Status status) { 
-        if(status == _status) 
-            return; 
-        _status = status; 
-        Q_EMIT statusChanged(_status); 
+    void setStatus(Status status) {
+        if(status == _status)
+            return;
+        _status = status;
+        Q_EMIT statusChanged(_status);
     }
 
     Q_SLOT DisplayMode displayMode() const { return _displayMode; }

--- a/src/depthMapEntity/plugin.hpp
+++ b/src/depthMapEntity/plugin.hpp
@@ -13,7 +13,12 @@ class DepthMapEntityPlugin : public QQmlExtensionPlugin
     Q_PLUGIN_METADATA(IID "depthMapEntity.qmlPlugin")
 
 public:
-    void initializeEngine(QQmlEngine* engine, const char* uri) override {}
+    void initializeEngine(QQmlEngine* engine, const char* uri) override
+    {
+        // Fix "unused parameter" warnings; should be replaced by [[maybe_unused]] when C++17 is supported
+        (void)engine;
+        (void)uri;
+    }
     void registerTypes(const char* uri) override
     {
         Q_ASSERT(uri == QLatin1String("DepthMapEntity"));

--- a/src/plugin.hpp
+++ b/src/plugin.hpp
@@ -24,7 +24,12 @@ class QtAliceVisionPlugin : public QQmlExtensionPlugin
 
 
 public:
-    void initializeEngine(QQmlEngine* engine, const char* uri) override {}
+    void initializeEngine(QQmlEngine* engine, const char* uri) override
+    {
+        // Fix "unused parameter" warnings; should be replaced by [[maybe_unused]] when C++17 is supported
+        (void)engine;
+        (void)uri;
+    }
     void registerTypes(const char* uri) override
     {
         qInfo() << "[QtAliceVision] Plugin Initialized";

--- a/src/plugin.hpp
+++ b/src/plugin.hpp
@@ -42,6 +42,7 @@ public:
         qRegisterMetaType<QList<QPointF*>>("QList<QPointF*>");
         qRegisterMetaType<QQmlListProperty<QPointF>>("QQmlListProperty<QPointF>");
         qRegisterMetaType<aliceVision::sfmData::SfMData>( "QSharedPtr<aliceVision::sfmData::SfMData>" ); // for usage in signals/slots
+        qRegisterMetaType<size_t>("size_t"); // for usage in signals/slots
 
         qmlRegisterType<FloatImageViewer>(uri, 1, 0, "FloatImageViewer");
         qmlRegisterType<Surface>(uri, 1, 0, "Surface");

--- a/src/qtAliceVisionImageIO/CMakeLists.txt
+++ b/src/qtAliceVisionImageIO/CMakeLists.txt
@@ -21,6 +21,15 @@ find_package(OpenImageIO REQUIRED)
 # Target properties
 add_library(qtAliceVisionImageIOPlugin SHARED ${PLUGIN_SOURCES} ${PLUGIN_HEADERS})
 
+if(MSVC)
+    target_compile_options(qtAliceVisionImageIOPlugin PUBLIC /W4)
+else()
+    target_compile_options(qtAliceVisionImageIOPlugin
+        PUBLIC
+        -Wall -Wextra -Wconversion -Wsign-conversion -Wshadow -Wpedantic
+        )
+endif()
+
 target_include_directories(qtAliceVisionImageIOPlugin 
     PUBLIC 
     ${OPENIMAGEIO_INCLUDE_DIRS}

--- a/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.cpp
+++ b/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.cpp
@@ -185,6 +185,7 @@ QVariant QtAliceVisionImageIOHandler::option(ImageOption option) const
         case 6: return QImageIOHandler::TransformationRotate90; break;
         case 7: return QImageIOHandler::TransformationMirrorAndRotate90; break;
         case 8: return QImageIOHandler::TransformationRotate270; break;
+        default: break;
         }
     }
     return QImageIOHandler::option(option);

--- a/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.cpp
+++ b/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.cpp
@@ -27,7 +27,7 @@ inline const float& clamp( const float& v, const float& lo, const float& hi )
 
 inline unsigned short floatToUShort(float v)
 {
-    return (unsigned short)(clamp(v, 0.0f, 1.0f) * 65535);
+    return static_cast<unsigned short>(clamp(v, 0.0f, 1.0f) * 65535);
 }
 
 QtAliceVisionImageIOHandler::QtAliceVisionImageIOHandler()
@@ -122,7 +122,7 @@ bool QtAliceVisionImageIOHandler::read(QImage *image)
 
     if (pixelAspectRatio != 1.0f)
     {
-        QSize newSize(static_cast<int>((float)inSpec.width * pixelAspectRatio), inSpec.height);
+        QSize newSize(static_cast<int>(static_cast<float>(inSpec.width) * pixelAspectRatio), inSpec.height);
         result = result.scaled(newSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
     }
 

--- a/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.cpp
+++ b/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.cpp
@@ -198,7 +198,8 @@ void QtAliceVisionImageIOHandler::setOption(ImageOption option, const QVariant &
     if (option == ScaledSize && value.isValid())
     {
         _scaledSize = value.value<QSize>();
-        qDebug() << "[QtAliceVisionImageIO] setOption scaledSize: " << _scaledSize.width() << "x" << _scaledSize.height();
+        qDebug() << "[QtAliceVisionImageIO] setOption scaledSize: "
+                 << _scaledSize.width() << "x" << _scaledSize.height();
     }
 }
 

--- a/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.cpp
+++ b/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.cpp
@@ -27,7 +27,7 @@ inline const float& clamp( const float& v, const float& lo, const float& hi )
 
 inline unsigned short floatToUShort(float v)
 {
-    return clamp(v, 0.0f, 1.0f) * 65535;
+    return (unsigned short)(clamp(v, 0.0f, 1.0f) * 65535);
 }
 
 QtAliceVisionImageIOHandler::QtAliceVisionImageIOHandler()
@@ -122,7 +122,7 @@ bool QtAliceVisionImageIOHandler::read(QImage *image)
 
     if (pixelAspectRatio != 1.0f)
     {
-        QSize newSize(inSpec.width * pixelAspectRatio, inSpec.height);
+        QSize newSize(static_cast<int>((float)inSpec.width * pixelAspectRatio), inSpec.height);
         result = result.scaled(newSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
     }
 
@@ -138,7 +138,7 @@ bool QtAliceVisionImageIOHandler::read(QImage *image)
     return true;
 }
 
-bool QtAliceVisionImageIOHandler::write(const QImage &image)
+bool QtAliceVisionImageIOHandler::write(const QImage&)
 {
     // TODO
     return false;

--- a/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.cpp
+++ b/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.cpp
@@ -19,9 +19,9 @@
 #include <memory>
 
 
-inline const float& clamp( const float& v, const float& lo, const float& hi )
+inline const float& clamp(const float& v, const float& lo, const float& hi)
 {
-    assert( !(hi < lo) );
+    assert(!(hi < lo));
     return (v < lo) ? lo : (hi < v) ? hi : v;
 }
 
@@ -66,7 +66,7 @@ bool QtAliceVisionImageIOHandler::canRead(QIODevice *device)
         return false;
     }
 
-    if (!(input->valid_file(path))) 
+    if (!(input->valid_file(path)))
     {
         qDebug() << "[QtAliceVisionImageIO] Cannot read: invalid file";
         return false;
@@ -92,15 +92,15 @@ bool QtAliceVisionImageIOHandler::read(QImage *image)
 
     oiio::ImageBuf inBuf;
     aliceVision::image::getBufferFromImage(img, inBuf);
-    
+
     oiio::ImageSpec inSpec = aliceVision::image::readImageSpec(path);
     float pixelAspectRatio = inSpec.get_float_attribute("PixelAspectRatio", 1.0f);
 
-    qDebug() << "[QtAliceVisionImageIO] width:" << inSpec.width 
-            << ", height:" << inSpec.height 
-            << ", nchannels:" << inSpec.nchannels  
+    qDebug() << "[QtAliceVisionImageIO] width:" << inSpec.width
+            << ", height:" << inSpec.height
+            << ", nchannels:" << inSpec.nchannels
             << ", pixelAspectRatio:" << pixelAspectRatio;
-    
+
     qDebug() << "[QtAliceVisionImageIO] create output QImage";
     QImage result(inSpec.width, inSpec.height, QImage::Format_RGB32);
 
@@ -113,7 +113,7 @@ bool QtAliceVisionImageIOHandler::read(QImage *image)
     float channelValues[] = {1.f, 1.f, 1.f, 1.f};
     oiio::ImageBufAlgo::channels(tmpBuf, inBuf, 4, channelOrder, channelValues, {}, false);
     inBuf.swap(tmpBuf);
-    
+
     qDebug() << "[QtAliceVisionImageIO] fill output QImage";
     oiio::ROI exportROI = inBuf.roi();
     exportROI.chbegin = 0;


### PR DESCRIPTION
This PR adds the following recommended compilation flags to all the QtAliceVision plugins (QtAliceVision, QtAliceVisionImageIO and DepthMapEntity):  `-Wall -Wextra -Wconversion -Wsign-conversion  -Wshadow -Wpedantic`.

All the warnings raised by these new flags (as well as those that existed prior to the addition of these flags) are fixed. Additionally, warnings raised by the `-Wswitch-default` and `-Wold-style-cast` flags are also fixed, although the flags themselves are not added to the plugins' compilation.

Most of the warnings that have been fixed consisted in:
- implicit casts (and C-style casts)
- incorrect syntax for Q_PROPERTY declarations
- calls to deprecated functions in OpenImageIO and Qt3D
- declaration of attributes in function prototypes that are needed but were never used

Finally, some minor clean-up has been performed in order to improve the readability: trailing spaces have been removed and lines of code that were very long, especially because of the explicit casting, have been split. Casts have also been limited when it was possible, which improves the code readability as well. 
