### PR TITLE
[FloatImageViewer] bug fix: image size change when navigating through images with feature viewer

### DIFF
--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -156,18 +156,8 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
     {
         for (size_t j = 0; j <= _subdivisions; j++)
         {
-            float x = 0.0f;
-            float y = 0.0f;
-            if (_vertices.empty())
-            {
-                x = i * textureSize.width() / (float)_subdivisions;
-                y = j * textureSize.height() / (float)_subdivisions;
-            }
-            else
-            {
-                x = _vertices[vertexIndex].x();
-                y = _vertices[vertexIndex].y();
-            }
+            float x = i * textureSize.width() / (float)_subdivisions;
+            float y = j * textureSize.height() / (float)_subdivisions;
 
             const double cx = x - center(0);
             const double cy = y - center(1);
@@ -185,7 +175,7 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
             float v = j / (float)_subdivisions;
 
             // Remove Distortion only if sfmData has been updated
-            if (intrinsic && intrinsic->hasDistortion())
+            if (isDistortionViewerEnabled() && intrinsic && intrinsic->hasDistortion())
             {
                 const aliceVision::Vec2 undisto_pix(x, y);
                 const aliceVision::Vec2 disto_pix = intrinsic->get_d_pixel(undisto_pix);


### PR DESCRIPTION
## Description

This PR fixes a bug noticed on some datasets when using the HDR viewer combined with the feature viewer: the image size would slightly change and these changes would accumulate when navigating through the images.

After some investigation, it turned out that there were 2 undesired phenomenon happening: 
- the image was undistorted by applying the camera distortion parameters to the surface vertices (i.e the four corners of the image), even though we were not using the lens distortion viewer
- the previously computed surface vertices were re-used to compute the next ones (hence the accumulation), even though we should recompute them from scratch each time.

Since enabling the feature viewer initializes the `MSfMData` object which is also used by the float image viewer, if the distortion parameters had been estimated it would start the process described above.

## Tests

This PR has been tested on 2 datasets where the bug was noticed. 
It did not happen again during our tests, and no impact has been noticed on the lens distortion viewer.