### PR TITLE
Update installation procedure with latest Meshroom-compatible Qt version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,7 @@ This guide will help you build and install QtAliceVision plugin.
 
 ## Requirements
 QtAliceVision requires:
-* [Qt5](https://www.qt.io/) (== 5.14.1, make sure to use the **same version** as the target application)
+* [Qt5](https://www.qt.io/) (== 5.15.2, make sure to use the **same version** as the target application)
 * [AliceVision](https://github.com/aliceVision/AliceVision)
 * [OpenImageIO](https://github.com/https://github.com/OpenImageIO/oiio) (>= 2.1) - with OpenEXR support for depthmaps visualization
 * [CMake](https://cmake.org/) (>= 3.11)
@@ -19,9 +19,9 @@ In the following steps, replace <INSTALL_PATH> with the installation path of you
 > We will use "NMake Makefiles" generators here to have one-line build/installation,
 but Visual Studio solutions can be generated if need be.
 
-From a developer command-line, using Qt 5.14.1 (built with VS2019) and VCPKG for OIIO:
+From a developer command-line, using Qt 5.15.2 (built with VS2019) and VCPKG for OIIO:
 ```
-set QT_DIR=/path/to/qt/5.14.1/msvc2019_64
+set QT_DIR=/path/to/qt/5.15.2/msvc2019_64
 set AV_DIR=/path/to/aliceVision/cmake/folder
 cmake .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -DAliceVision_DIR=%AV_DIR% -DCMAKE_PREFIX_PATH=%QT_DIR% -DVCPKG_TARGET_TRIPLET=x64-windows -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=<INSTALL_PATH> 
 nmake install
@@ -30,7 +30,7 @@ nmake install
 #### Linux
 
 ```bash
-export QT_DIR=/path/to/qt/5.14.1/gcc_64
+export QT_DIR=/path/to/qt/5.15.2/gcc_64
 export OPENIMAGEIO_DIR=/path/to/oiio/install
 cmake .. -DAliceVision_DIR=$AV_DIR -DOPENIMAGEIO_LIBRARY_DIR_HINTS:PATH=$OPENIMAGEIO_DIR/lib/ -DOPENIMAGEIO_INCLUDE_DIR:PATH=$OPENIMAGEIO_DIR/include/ -DCMAKE_PREFIX_PATH=$QT_DIR -DCMAKE_INSTALL_PREFIX=<INSTALL_PATH> -DCMAKE_BUILD_TYPE=Release
 make install


### PR DESCRIPTION
This PR is related to https://github.com/alicevision/Meshroom/pull/1882 and should be merged at the same time.

Meshroom now uses Qt 5.15.2, so the installation procedure needs to be updated accordingly.

The QtAliceVIsion plugin itself does not undergo any modification as a consequence of Meshroom's update, but it will need to be rebuilt with Qt 5.15.2 to work properly.