### PR TITLE
[DepthMapEntity] Handle cases where depth maps or sim maps do not exist

### DIFF
--- a/src/depthMapEntity/DepthMapEntity.cpp
+++ b/src/depthMapEntity/DepthMapEntity.cpp
@@ -47,7 +47,7 @@ void DepthMapEntity::setSource(const QUrl& value)
 
     if(!value.isValid())
     {
-        qDebug() << "[DepthMapEntity] invalid source";
+        qDebug() << "[DepthMapEntity] Invalid source";
         _status = DepthMapEntity::Error;
         return;
     }
@@ -242,7 +242,7 @@ void DepthMapEntity::loadDepthMap()
     // Load depth map and metadata
 
     const std::string depthMapPath = _depthMapSource.toLocalFile().toStdString();
-    qDebug() << "[DepthMapEntity] load depth map: " << _depthMapSource.toLocalFile();
+    qDebug() << "[DepthMapEntity] Load depth map: " << _depthMapSource.toLocalFile();
     image::Image<float> depthMap;
     try {
         image::readImage(depthMapPath, depthMap, image::EImageColorSpace::LINEAR);
@@ -268,7 +268,7 @@ void DepthMapEntity::loadDepthMap()
     }
     else
     {
-        qDebug() << "[DepthMapEntity] missing metadata CArr.";
+        qDebug() << "[DepthMapEntity] Missing metadata CArr.";
         _status = DepthMapEntity::Error;
         return;
     }
@@ -284,7 +284,7 @@ void DepthMapEntity::loadDepthMap()
     }
     else
     {
-        qDebug() << "[DepthMapEntity] missing metadata iCamArr.";
+        qDebug() << "[DepthMapEntity] Missing metadata iCamArr.";
         _status = DepthMapEntity::Error;
         return;
     }
@@ -295,7 +295,7 @@ void DepthMapEntity::loadDepthMap()
     if(_simMapSource.isValid())
     {
         const std::string simMapPath = _simMapSource.toLocalFile().toStdString();
-        qDebug() << "[DepthMapEntity] load sim map: " << _simMapSource.toLocalFile();
+        qDebug() << "[DepthMapEntity] Load sim map: " << _simMapSource.toLocalFile();
         try {
             image::readImage(simMapPath, simMap, image::EImageColorSpace::LINEAR);
         } catch (const std::runtime_error& error) {
@@ -311,7 +311,7 @@ void DepthMapEntity::loadDepthMap()
 
     // 3D points position and color (using jetColorMap)
 
-    qDebug() << "[DepthMapEntity] computing positions and colors for point cloud";
+    qDebug() << "[DepthMapEntity] Computing positions and colors for point cloud";
 
     std::vector<int> indexPerPixel(static_cast<std::size_t>(depthMap.Width() * depthMap.Height()), -1);
     std::vector<Vec3f> positions;
@@ -351,7 +351,7 @@ void DepthMapEntity::loadDepthMap()
 
     // Create geometry
 
-    qDebug() << "[DepthMapEntity] creating geometry";
+    qDebug() << "[DepthMapEntity] Creating geometry";
 
     QGeometry* customGeometry = new QGeometry;
 

--- a/src/depthMapEntity/DepthMapEntity.cpp
+++ b/src/depthMapEntity/DepthMapEntity.cpp
@@ -44,7 +44,7 @@ void DepthMapEntity::setSource(const QUrl& value)
 {
     if(_source == value)
         return;
-    
+
     if(!value.isValid())
     {
         qDebug() << "[DepthMapEntity] invalid source";
@@ -116,9 +116,9 @@ void DepthMapEntity::updateMaterial()
         break;
     case DisplayMode::Triangles:
         _meshRenderer->setPrimitiveType(Qt3DRender::QGeometryRenderer::Triangles);
-        if(_displayColor) 
+        if(_displayColor)
             newMaterial = _colorMaterial;
-        else 
+        else
             newMaterial = _diffuseMaterial;
         break;
     default:


### PR DESCRIPTION
## Description

The depth and sim maps are identified by taking the filename of the loaded file (may it be the depth map or the sim map) and finding its counterpart by replacing "depthMap" by "simMap" (or "simMap" by "depthMap") in the filename. Whether the files exist is not checked until we attempt to read the maps.

`image::readImage` throws a `std::runtime_error` if the file does not exist or if some other issues occur while reading it. As both the depth map and sim map are expected, if one is missing, we still attempt to read it and an exception is thrown without being handled, causing the application to crash.

This PR fixes that issue by trying/catching `std::runtime_error` exceptions when reading the images:
- If the depth map does not exist, the loading process is interrupted and the DepthMapEntity status is updated to "Error".
- If the sim map does not exist, we keep on going with the whole process: the sim map will later be deemed as invalid, and only the depth map will be displayed.

This prevents crashes from happening in any case where there might be a depth map without a corresponding sim map.

Additionally, the PR removes some trailing spaces, harmonizes the debug messages, and increases the level of some logs that indicate errors.

