### PR TITLE
FloatImageViewer: support multi-resolution

### DIFF
--- a/src/qtAliceVision/FloatImageViewer.cpp
+++ b/src/qtAliceVision/FloatImageViewer.cpp
@@ -133,6 +133,12 @@ void FloatImageViewer::reload()
     Q_EMIT cachedFramesChanged();
 }
 
+void FloatImageViewer::playback(bool active)
+{
+    // Turn off interactive prefetching when playback is ON
+    _sequenceCache.setInteractivePrefetching(!active);
+}
+
 QVector4D FloatImageViewer::pixelValueAt(int x, int y)
 {
     if (!_image)

--- a/src/qtAliceVision/FloatImageViewer.cpp
+++ b/src/qtAliceVision/FloatImageViewer.cpp
@@ -45,7 +45,7 @@ FloatImageViewer::FloatImageViewer(QQuickItem* parent)
 
     connect(&_singleImageLoader, &imgserve::SingleImageLoader::requestHandled, this, &FloatImageViewer::reload);
     connect(&_sequenceCache, &imgserve::SequenceCache::requestHandled, this, &FloatImageViewer::reload);
-    connect(this, &FloatImageViewer::sequenceChanged, this, &FloatImageViewer::reload);
+    connect(&_sequenceCache, &imgserve::SequenceCache::contentChanged, this, &FloatImageViewer::reload);
     connect(this, &FloatImageViewer::useSequenceChanged, this, &FloatImageViewer::reload);
 }
 
@@ -73,7 +73,6 @@ void FloatImageViewer::setTargetSize(int size)
 {
     _sequenceCache.setTargetSize(size);
     Q_EMIT targetSizeChanged();
-    Q_EMIT sequenceChanged();
 }
 
 QVariantList FloatImageViewer::getCachedFrames() const

--- a/src/qtAliceVision/FloatImageViewer.cpp
+++ b/src/qtAliceVision/FloatImageViewer.cpp
@@ -43,8 +43,8 @@ FloatImageViewer::FloatImageViewer(QQuickItem* parent)
     connect(&_surface, &Surface::subdivisionsChanged, this, &FloatImageViewer::update);
     connect(&_surface, &Surface::verticesChanged, this, &FloatImageViewer::update);
 
-    connect(&_sequenceCache, &imgserve::SequenceCache::requestHandled, this, &FloatImageViewer::reload);
     connect(&_singleImageLoader, &imgserve::SingleImageLoader::requestHandled, this, &FloatImageViewer::reload);
+    connect(&_sequenceCache, &imgserve::SequenceCache::requestHandled, this, &FloatImageViewer::reload);
     connect(this, &FloatImageViewer::sequenceChanged, this, &FloatImageViewer::reload);
     connect(this, &FloatImageViewer::useSequenceChanged, this, &FloatImageViewer::reload);
 }
@@ -66,7 +66,13 @@ void FloatImageViewer::setLoading(bool loading)
 void FloatImageViewer::setSequence(const QVariantList& paths)
 {
     _sequenceCache.setSequence(paths);
+    Q_EMIT sequenceChanged();
+}
 
+void FloatImageViewer::setTargetSize(int size)
+{
+    _sequenceCache.setTargetSize(size);
+    Q_EMIT targetSizeChanged();
     Q_EMIT sequenceChanged();
 }
 
@@ -354,7 +360,7 @@ void FloatImageViewer::updatePaintSurface(QSGGeometryNode* root, QSGSimpleMateri
         quint16* indices = root->geometry()->indexDataAsUShort();
 
         // Update surface
-        _surface.update(vertices, indices, _textureSize, _downscaleLevel);
+        _surface.update(vertices, indices, _sourceSize, _downscaleLevel);
 
         root->geometry()->markIndexDataDirty();
         root->geometry()->markVertexDataDirty();

--- a/src/qtAliceVision/FloatImageViewer.cpp
+++ b/src/qtAliceVision/FloatImageViewer.cpp
@@ -359,7 +359,8 @@ void FloatImageViewer::updatePaintSurface(QSGGeometryNode* root, QSGSimpleMateri
         quint16* indices = root->geometry()->indexDataAsUShort();
 
         // Update surface
-        _surface.update(vertices, indices, _sourceSize, _downscaleLevel);
+        const QSize surfaceSize = _surface.isPanoramaViewerEnabled() ? _textureSize : _sourceSize;
+        _surface.update(vertices, indices, surfaceSize, _downscaleLevel);
 
         root->geometry()->markIndexDataDirty();
         root->geometry()->markVertexDataDirty();

--- a/src/qtAliceVision/FloatImageViewer.hpp
+++ b/src/qtAliceVision/FloatImageViewer.hpp
@@ -127,6 +127,7 @@ public:
 
     // Q_INVOKABLE
     Q_INVOKABLE QVector4D pixelValueAt(int x, int y);
+    Q_INVOKABLE void playback(bool active);
 
     Surface* getSurfacePtr() { return &_surface; }
 

--- a/src/qtAliceVision/FloatImageViewer.hpp
+++ b/src/qtAliceVision/FloatImageViewer.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <algorithm>
 
 namespace qtAliceVision
 {
@@ -58,9 +59,12 @@ class FloatImageViewer : public QQuickItem
 
     Q_PROPERTY(QVariantList sequence WRITE setSequence NOTIFY sequenceChanged)
 
+    Q_PROPERTY(int targetSize WRITE setTargetSize NOTIFY targetSizeChanged)
+
     Q_PROPERTY(QVariantList cachedFrames READ getCachedFrames NOTIFY cachedFramesChanged)
 
     Q_PROPERTY(bool useSequence MEMBER _useSequence NOTIFY useSequenceChanged)
+
 
 public:
     explicit FloatImageViewer(QQuickItem* parent = nullptr);
@@ -80,12 +84,8 @@ public:
         if (level == _downscaleLevel)
             return;
 
-        // Level [0;3]
-        if (level < 0 && level > 6)
-            level = 4;
-        _downscaleLevel = level;
-        reload();
-        // Q_EMIT downscaleLevelChanged();
+        _downscaleLevel = std::max(0, level);
+        Q_EMIT downscaleLevelChanged();
     }
 
     enum class EChannelMode : quint8
@@ -121,6 +121,7 @@ public:
     Q_SIGNAL void sfmRequiredChanged();
     Q_SIGNAL void fisheyeCircleParametersChanged();
     Q_SIGNAL void sequenceChanged();
+    Q_SIGNAL void targetSizeChanged();
     Q_SIGNAL void cachedFramesChanged();
     Q_SIGNAL void useSequenceChanged();
 
@@ -130,6 +131,8 @@ public:
     Surface* getSurfacePtr() { return &_surface; }
 
     void setSequence(const QVariantList& paths);
+
+    void setTargetSize(int size);
 
     QVariantList getCachedFrames() const;
 

--- a/src/qtAliceVision/ImageServer.hpp
+++ b/src/qtAliceVision/ImageServer.hpp
@@ -58,6 +58,7 @@ public:
 } // namespace imgserve
 } // namespace qtAliceVision
 
-// Make ResponseData struct known to QMetaType
+// Make RequestData and ResponseData struct known to QMetaType
 // for usage in signals and slots
+Q_DECLARE_METATYPE(qtAliceVision::imgserve::RequestData)
 Q_DECLARE_METATYPE(qtAliceVision::imgserve::ResponseData)

--- a/src/qtAliceVision/SequenceCache.cpp
+++ b/src/qtAliceVision/SequenceCache.cpp
@@ -41,6 +41,7 @@ SequenceCache::SequenceCache(QObject* parent) :
     // Initialize internal state
     _regionSafe = std::make_pair(-1, -1);
     _loading = false;
+    _interactivePrefetching = true;
     _targetSize = 1000;
 }
 
@@ -109,6 +110,11 @@ void SequenceCache::setSequence(const QVariantList& paths)
 
     // Notify listeners that sequence content has changed
     Q_EMIT contentChanged();
+}
+
+void SequenceCache::setInteractivePrefetching(bool interactive)
+{
+    _interactivePrefetching = interactive;
 }
 
 void SequenceCache::setTargetSize(int size)
@@ -217,7 +223,7 @@ ResponseData SequenceCache::request(const RequestData& reqData)
 
     // Requested image is not in cache
     // and there is already a prefetching thread running
-    if (!response.img && _loading)
+    if (!response.img && _loading && _interactivePrefetching)
     {
         // Abort prefetching to avoid waiting until current worker thread is done
         abortPrefetching = true;

--- a/src/qtAliceVision/SequenceCache.cpp
+++ b/src/qtAliceVision/SequenceCache.cpp
@@ -46,6 +46,14 @@ SequenceCache::SequenceCache(QObject* parent) :
 
 SequenceCache::~SequenceCache()
 {
+    // Check if a worker thread is currently active
+    if (_loading)
+    {
+        // Worker thread will return on next iteration
+        abortPrefetching = true;
+        QThreadPool::globalInstance()->waitForDone();
+    }
+
     // Free memory occupied by image cache
     if (_cache) delete _cache;
 }

--- a/src/qtAliceVision/SequenceCache.cpp
+++ b/src/qtAliceVision/SequenceCache.cpp
@@ -98,6 +98,9 @@ void SequenceCache::setSequence(const QVariantList& paths)
             std::cerr << e.what() << std::endl;
         }
     }
+
+    // Notify listeners that sequence content has changed
+    Q_EMIT contentChanged();
 }
 
 void SequenceCache::setTargetSize(int size)
@@ -124,6 +127,9 @@ void SequenceCache::setTargetSize(int size)
     {
         // Clear internal state
         _regionSafe = std::make_pair(-1, -1);
+
+        // Notify listeners that sequence content has changed
+        Q_EMIT contentChanged();
     }
 }
 

--- a/src/qtAliceVision/SequenceCache.hpp
+++ b/src/qtAliceVision/SequenceCache.hpp
@@ -74,6 +74,12 @@ public:
     void setSequence(const QVariantList& paths);
 
     /**
+     * @brief Toggle on/off interactive prefetching.
+     * @param[in] interactive new value for interactive prefetching flag
+     */
+    void setInteractivePrefetching(bool interactive);
+
+    /**
      * @brief Set the target size for the images in the sequence.
      * @param[in] size target size
      */
@@ -131,6 +137,9 @@ private:
 
     /// Keep track of whether or not there is an active worker thread.
     bool _loading;
+
+    /// Allow main thread to abort the prefetching thread and restart a centered around a more accurate location
+    bool _interactivePrefetching;
 
     /// Target size used to compute downscale
     int _targetSize;

--- a/src/qtAliceVision/SequenceCache.hpp
+++ b/src/qtAliceVision/SequenceCache.hpp
@@ -111,6 +111,11 @@ public:
      */
     Q_SIGNAL void requestHandled();
 
+    /**
+     * @brief Signal emitted when sequence content has been modified.
+     */
+    Q_SIGNAL void contentChanged();
+
 private:
 
     // Member variables

--- a/src/qtAliceVision/SequenceCache.hpp
+++ b/src/qtAliceVision/SequenceCache.hpp
@@ -34,6 +34,8 @@ struct FrameData {
 
     int frame;
 
+    int downscale;
+
 };
 
 /**
@@ -70,6 +72,12 @@ public:
      * @note the sequence order will not be changed
      */
     void setSequence(const QVariantList& paths);
+
+    /**
+     * @brief Set the target size for the images in the sequence.
+     * @param[in] size target size
+     */
+    void setTargetSize(int size);
 
     /**
      * @brief Get the frames in the sequence that are currently cached.
@@ -118,6 +126,9 @@ private:
 
     /// Keep track of whether or not there is an active worker thread.
     bool _loading;
+
+    /// Target size used to compute downscale
+    int _targetSize;
 
 private:
 

--- a/src/qtAliceVision/SingleImageLoader.cpp
+++ b/src/qtAliceVision/SingleImageLoader.cpp
@@ -22,7 +22,7 @@ SingleImageLoader::~SingleImageLoader()
 ResponseData SingleImageLoader::request(const RequestData& reqData)
 {
 	// Check if requested image matches currently loaded image
-	if (reqData.path == _path)
+	if (reqData.path == _request.path && reqData.downscale == _request.downscale)
 	{
 		return _response;
 	}
@@ -44,11 +44,11 @@ ResponseData SingleImageLoader::request(const RequestData& reqData)
 	return ResponseData();
 }
 
-void SingleImageLoader::onSingleImageLoadingDone(QString path, ResponseData response)
+void SingleImageLoader::onSingleImageLoadingDone(RequestData reqData, ResponseData response)
 {
 	// Update internal state
 	_loading = false;
-	_path = path.toStdString();
+	_request = reqData;
 	_response = response;
 
 	// Notify listeners that an image has been loaded
@@ -98,7 +98,7 @@ void SingleImageLoadingIORunnable::run()
     }
 
     // Notify listeners that loading is finished
-    Q_EMIT done(QString::fromStdString(_reqData.path), response);
+    Q_EMIT done(_reqData, response);
 }
 
 } // namespace imgserve

--- a/src/qtAliceVision/SingleImageLoader.hpp
+++ b/src/qtAliceVision/SingleImageLoader.hpp
@@ -37,10 +37,10 @@ public:
 
 	/**
 	 * @brief Slot called when the loading thread is done.
-	 * @param[in] path filepath of the loaded image
+	 * @param[in] reqData request data used to create the loading thread
 	 * @param[in] response a ResponseData instance containing the data loaded from disk
 	 */
-	Q_SLOT void onSingleImageLoadingDone(QString path, ResponseData response);
+	Q_SLOT void onSingleImageLoadingDone(RequestData reqData, ResponseData response);
 
 	/**
 	 * @brief Signal emitted when the loading thread is done and a previous request has been handled.
@@ -51,10 +51,10 @@ private:
 
 	// Member variables
 
-	/// Filepath of currently loaded image.
-	std::string _path;
+	/// Latest request data.
+	RequestData _request;
 
-	/// Currently loaded image and its metadata.
+	/// Latest response data.
 	ResponseData _response;
 
 	/// Keep track of whether or not there is an active worker thread.
@@ -83,10 +83,10 @@ public:
 
 	/**
 	 * @brief Signal emitted when image loading is finished.
-	 * @param[in] path filepath of the loaded image
+	 * @param[in] reqData request data used to create the loading thread
 	 * @param[in] response a ResponseData instance containing the data loaded from disk
 	 */
-	Q_SIGNAL void done(QString path, ResponseData response);
+	Q_SIGNAL void done(RequestData reqData, ResponseData response);
 
 private:
 

--- a/src/qtAliceVision/plugin.hpp
+++ b/src/qtAliceVision/plugin.hpp
@@ -60,6 +60,8 @@ public:
 
         qRegisterMetaType<Surface*>("Surface*");
 
+        qRegisterMetaType<imgserve::RequestData>("RequestData");
+        qRegisterMetaType<imgserve::RequestData>("imgserve::RequestData");
         qRegisterMetaType<imgserve::ResponseData>("ResponseData");
         qRegisterMetaType<imgserve::ResponseData>("imgserve::ResponseData");
     }


### PR DESCRIPTION
## Description

Modifications to the `FloatImageViewer` and `SequenceCache` to adapt the images resolution to a given target size.

This PR also includes several improvements regarding request management and prefetching.

## Features

- [X] use target size to determine downscale
- [X] make sure there is always at most one prefetching thread
- [X] add flag to abort prefetching

Also we rely on https://github.com/alicevision/AliceVision/pull/1504 to allow retrieving images from cache while images are loading from disk in the prefetching thread, which avoids blocking the UI.