### PR TITLE
Add visualisation mode for landmarks observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Currently available:
   - [X] Alembic 3D visualization
     - Point clouds
     - Cameras
+    - Landmark observations
   - [X] OIIO backend
     - Read RAW images from DSLRs
     - Read intermediate files of the [AliceVision](https://github.com/alicevision/AliceVision) framework stored in EXR format

--- a/src/qmlAlembic/AlembicEntity.cpp
+++ b/src/qmlAlembic/AlembicEntity.cpp
@@ -28,6 +28,7 @@ AlembicEntity::AlembicEntity(Qt3DCore::QNode* parent)
 
     // trigger display repaint events of observations
     connect(this, &AlembicEntity::viewIdChanged, this, &AlembicEntity::updateObservations);
+    connect(this, &AlembicEntity::displayObservationsChanged, this, &AlembicEntity::updateObservations);
     connect(this, &AlembicEntity::viewer2DInfoChanged, this, &AlembicEntity::updateObservations);
 }
 
@@ -67,6 +68,14 @@ void AlembicEntity::setViewId(const int& value)
     Q_EMIT viewIdChanged();
 }
 
+void AlembicEntity::setDisplayObservations(const bool& value)
+{
+    if (_displayObservations == value)
+        return;
+    _displayObservations = value;
+    Q_EMIT displayObservationsChanged();
+}
+
 void AlembicEntity::setViewer2DInfo(const QVariantMap& value)
 {
     if (_viewer2DInfo == value)
@@ -89,6 +98,8 @@ void AlembicEntity::updateObservations() const
     for (auto* entity : _observations)
     {
         entity->update(_viewId, _viewer2DInfo);
+        if (entity->isEnabled() != _displayObservations)
+            entity->setEnabled(_displayObservations);
     }
 }
 

--- a/src/qmlAlembic/AlembicEntity.cpp
+++ b/src/qmlAlembic/AlembicEntity.cpp
@@ -241,7 +241,7 @@ void AlembicEntity::visitAbcObject(const Alembic::Abc::IObject& iObj, QEntity* p
             entity0->fillUserProperties(points.getSchema().getUserProperties());
             entities[0] = entity0;
             ObservationsEntity* entity1 = new ObservationsEntity(_source.toLocalFile().toStdString(), parent);
-            entity1->setData(iObj);
+            entity1->setData();
             entity1->fillArbProperties(points.getSchema().getArbGeomParams());
             entity1->fillUserProperties(points.getSchema().getUserProperties());
             entities[1] = entity1;

--- a/src/qmlAlembic/AlembicEntity.cpp
+++ b/src/qmlAlembic/AlembicEntity.cpp
@@ -97,7 +97,7 @@ void AlembicEntity::updateObservations() const
 {
     for (auto* entity : _observations)
     {
-        entity->update(_viewId, _viewer2DInfo);
+        entity->update(static_cast<aliceVision::IndexT>(_viewId), _viewer2DInfo);
         if (entity->isEnabled() != _displayObservations)
             entity->setEnabled(_displayObservations);
     }
@@ -289,7 +289,7 @@ void AlembicEntity::visitAbcObject(const Alembic::Abc::IObject& iObj, QEntity* p
 
     std::vector<BaseAlembicObject*> entities = createEntities(iObj);
 
-    for (int j = 0; j < entities.size(); j++)
+    for (size_t j = 0; j < entities.size(); j++)
     {
         auto entity = entities[j];
         entity->setObjectName((iObj.getName() + std::to_string(j)).c_str());

--- a/src/qmlAlembic/AlembicEntity.hpp
+++ b/src/qmlAlembic/AlembicEntity.hpp
@@ -13,6 +13,7 @@ namespace abcentity
 {
 class CameraLocatorEntity;
 class PointCloudEntity;
+class ObservationsEntity;
 class IOThread;
 
 class AlembicEntity : public Qt3DCore::QEntity
@@ -22,8 +23,12 @@ class AlembicEntity : public Qt3DCore::QEntity
     Q_PROPERTY(bool skipHidden MEMBER _skipHidden NOTIFY skipHiddenChanged)
     Q_PROPERTY(float pointSize READ pointSize WRITE setPointSize NOTIFY pointSizeChanged)
     Q_PROPERTY(float locatorScale READ locatorScale WRITE setLocatorScale NOTIFY locatorScaleChanged)
+    Q_PROPERTY(int viewId READ viewId WRITE setViewId NOTIFY viewIdChanged)
+    Q_PROPERTY(QVariantMap viewer2DInfo READ viewer2DInfo WRITE setViewer2DInfo NOTIFY viewer2DInfoChanged)
     Q_PROPERTY(QQmlListProperty<abcentity::CameraLocatorEntity> cameras READ cameras NOTIFY camerasChanged)
     Q_PROPERTY(QQmlListProperty<abcentity::PointCloudEntity> pointClouds READ pointClouds NOTIFY pointCloudsChanged)
+    Q_PROPERTY(
+        QQmlListProperty<abcentity::ObservationsEntity> observations READ observations NOTIFY observationsChanged)
 
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
 
@@ -43,9 +48,13 @@ public:
     Q_SLOT const QUrl& source() const { return _source; }
     Q_SLOT float pointSize() const { return _pointSize; }
     Q_SLOT float locatorScale() const { return _locatorScale; }
+    Q_SLOT float viewId() const { return _viewId; }
+    Q_SLOT QVariantMap viewer2DInfo() const { return _viewer2DInfo; }
     Q_SLOT void setSource(const QUrl& source);
     Q_SLOT void setPointSize(const float& value);
     Q_SLOT void setLocatorScale(const float& value);
+    Q_SLOT void setViewId(const int& value);
+    Q_SLOT void setViewer2DInfo(const QVariantMap& value);
 
     Status status() const { return _status; }
     void setStatus(Status status) {
@@ -70,12 +79,19 @@ private:
         return {this, &_pointClouds};
     }
 
+    QQmlListProperty<ObservationsEntity> observations() {
+        return {this, &_observations};
+    }
+
 public:
     Q_SIGNAL void sourceChanged();
     Q_SIGNAL void camerasChanged();
     Q_SIGNAL void pointSizeChanged();
     Q_SIGNAL void pointCloudsChanged();
+    Q_SIGNAL void observationsChanged();
     Q_SIGNAL void locatorScaleChanged();
+    Q_SIGNAL void viewIdChanged();
+    Q_SIGNAL void viewer2DInfoChanged();
     Q_SIGNAL void objectPicked(Qt3DCore::QTransform* transform);
     Q_SIGNAL void statusChanged(Status status);
     Q_SIGNAL void skipHiddenChanged();
@@ -83,6 +99,8 @@ public:
 protected:
     /// Scale child locators
     void scaleLocators() const;
+
+    void updateObservations() const;
 
     void onIOThreadFinished();
 
@@ -92,11 +110,14 @@ private:
     bool _skipHidden = false;
     float _pointSize = 0.5f;
     float _locatorScale = 1.0f;
+    int _viewId = 0;
+    QVariantMap _viewer2DInfo;
     Qt3DRender::QParameter* _pointSizeParameter;
     Qt3DRender::QMaterial* _cloudMaterial;
     Qt3DRender::QMaterial* _cameraMaterial;
     QList<CameraLocatorEntity*> _cameras;
     QList<PointCloudEntity*> _pointClouds;
+    QList<ObservationsEntity*> _observations;
     std::unique_ptr<IOThread> _ioThread;
 };
 

--- a/src/qmlAlembic/AlembicEntity.hpp
+++ b/src/qmlAlembic/AlembicEntity.hpp
@@ -25,6 +25,7 @@ class AlembicEntity : public Qt3DCore::QEntity
     Q_PROPERTY(float locatorScale READ locatorScale WRITE setLocatorScale NOTIFY locatorScaleChanged)
     Q_PROPERTY(int viewId READ viewId WRITE setViewId NOTIFY viewIdChanged)
     Q_PROPERTY(QVariantMap viewer2DInfo READ viewer2DInfo WRITE setViewer2DInfo NOTIFY viewer2DInfoChanged)
+    Q_PROPERTY(bool displayObservations READ displayObservations WRITE setDisplayObservations NOTIFY displayObservationsChanged)
     Q_PROPERTY(QQmlListProperty<abcentity::CameraLocatorEntity> cameras READ cameras NOTIFY camerasChanged)
     Q_PROPERTY(QQmlListProperty<abcentity::PointCloudEntity> pointClouds READ pointClouds NOTIFY pointCloudsChanged)
     Q_PROPERTY(
@@ -49,11 +50,13 @@ public:
     Q_SLOT float pointSize() const { return _pointSize; }
     Q_SLOT float locatorScale() const { return _locatorScale; }
     Q_SLOT float viewId() const { return _viewId; }
+    Q_SLOT bool displayObservations() const { return _displayObservations; }
     Q_SLOT QVariantMap viewer2DInfo() const { return _viewer2DInfo; }
     Q_SLOT void setSource(const QUrl& source);
     Q_SLOT void setPointSize(const float& value);
     Q_SLOT void setLocatorScale(const float& value);
     Q_SLOT void setViewId(const int& value);
+    Q_SLOT void setDisplayObservations(const bool& value);
     Q_SLOT void setViewer2DInfo(const QVariantMap& value);
 
     Status status() const { return _status; }
@@ -92,6 +95,7 @@ public:
     Q_SIGNAL void locatorScaleChanged();
     Q_SIGNAL void viewIdChanged();
     Q_SIGNAL void viewer2DInfoChanged();
+    Q_SIGNAL void displayObservationsChanged();
     Q_SIGNAL void objectPicked(Qt3DCore::QTransform* transform);
     Q_SIGNAL void statusChanged(Status status);
     Q_SIGNAL void skipHiddenChanged();
@@ -111,6 +115,7 @@ private:
     float _pointSize = 0.5f;
     float _locatorScale = 1.0f;
     int _viewId = 0;
+    bool _displayObservations = false;
     QVariantMap _viewer2DInfo;
     Qt3DRender::QParameter* _pointSizeParameter;
     Qt3DRender::QMaterial* _cloudMaterial;

--- a/src/qmlAlembic/AlembicEntity.hpp
+++ b/src/qmlAlembic/AlembicEntity.hpp
@@ -49,7 +49,7 @@ public:
     Q_SLOT const QUrl& source() const { return _source; }
     Q_SLOT float pointSize() const { return _pointSize; }
     Q_SLOT float locatorScale() const { return _locatorScale; }
-    Q_SLOT float viewId() const { return _viewId; }
+    Q_SLOT int viewId() const { return _viewId; }
     Q_SLOT bool displayObservations() const { return _displayObservations; }
     Q_SLOT QVariantMap viewer2DInfo() const { return _viewer2DInfo; }
     Q_SLOT void setSource(const QUrl& source);

--- a/src/qmlAlembic/CMakeLists.txt
+++ b/src/qmlAlembic/CMakeLists.txt
@@ -5,6 +5,7 @@ set(PLUGIN_SOURCES
     CameraLocatorEntity.cpp
     IOThread.cpp
     PointCloudEntity.cpp
+    ObservationsEntity.cpp
     )
 
 set(PLUGIN_HEADERS
@@ -13,6 +14,7 @@ set(PLUGIN_HEADERS
     CameraLocatorEntity.hpp
     IOThread.hpp
     PointCloudEntity.hpp
+    ObservationsEntity.hpp
     plugin.hpp
     )
 
@@ -49,8 +51,9 @@ target_link_libraries(alembicEntityQmlPlugin
     Qt5::3DCore
     Qt5::3DRender
     Alembic::Alembic
-    PRIVATE
     Qt5::3DExtras
+    aliceVision_sfmData
+    aliceVision_sfmDataIO
     )
 
 set_target_properties(alembicEntityQmlPlugin

--- a/src/qmlAlembic/ObservationsEntity.cpp
+++ b/src/qmlAlembic/ObservationsEntity.cpp
@@ -75,11 +75,11 @@ void ObservationsEntity::setData(const Alembic::Abc::IObject& iObj)
 
     auto* tcEntity = new QEntity(this);
     tcEntity->addComponent(tcGeometry);
-    tcEntity->addComponent(createMaterial(0, 1, 0, .7f));
+    tcEntity->addComponent(createMaterial(0, 1, 0, 1));
 
     auto* rcEntity = new QEntity(this);
     rcEntity->addComponent(rcGeometry);
-    rcEntity->addComponent(createMaterial(0, 0, 1, .7f));
+    rcEntity->addComponent(createMaterial(0, 0, 1, 1));
 }
 
 void ObservationsEntity::update(const IndexT& viewId, const QVariantMap& viewer2DInfo)

--- a/src/qmlAlembic/ObservationsEntity.cpp
+++ b/src/qmlAlembic/ObservationsEntity.cpp
@@ -1,0 +1,282 @@
+#include "ObservationsEntity.hpp"
+#include <Qt3DRender/QGeometryRenderer>
+#include <Qt3DRender/QAttribute>
+#include <Qt3DRender/QBuffer>
+#include <Qt3DExtras/QPhongAlphaMaterial>
+
+#include <aliceVision/sfmDataIO/AlembicImporter.cpp>
+
+using namespace Qt3DRender;
+using namespace aliceVision;
+
+namespace abcentity
+{
+
+static const auto& TC_INDEX_ATTRIBUTE_NAME = "Tc-observations indices";
+static const auto& RC_INDEX_ATTRIBUTE_NAME = "Rc-observations indices";
+
+/**
+ * @brief encapsulates sufficient and fast retrievable information on a landmark observed by a view
+ */
+struct LandmarkPerView
+{
+    LandmarkPerView() = default;
+
+    LandmarkPerView(const IndexT& landmarkId, const sfmData::Landmark& landmark,
+                    const sfmData::Observation& observation)
+        : landmarkId(landmarkId)
+        , landmark(landmark)
+        , observation(observation)
+    {
+    }
+
+    const uint& landmarkId;
+    const sfmData::Landmark& landmark;
+    const sfmData::Observation& observation;
+};
+
+// helper functions
+
+QGeometryRenderer* createGeometryRenderer(const QByteArray& positionData, const std::string& indexAttributeName);
+QMaterial* createMaterial(const float& r, const float& g, const float& b, const float& a);
+
+ObservationsEntity::ObservationsEntity(std::string source, Qt3DCore::QNode* parent)
+    : BaseAlembicObject(parent)
+    , _source(source)
+{
+    using sfmDataIO::ESfMData;
+
+    // read relevant SfM data
+    sfmDataIO::Load(_sfmData, _source, ESfMData(
+        ESfMData::VIEWS | ESfMData::EXTRINSICS | ESfMData::STRUCTURE | 
+        ESfMData::OBSERVATIONS | ESfMData::OBSERVATIONS_WITH_FEATURES));
+
+    // populate _landmarksPerView from the read SfM data
+    fillLandmarksPerViews();
+}
+
+void ObservationsEntity::setData(const Alembic::Abc::IObject& iObj)
+{
+    // contains the 3D coordinates of vertices in space in the following order:
+    // - the landmarks
+    // - the view cameras
+    QByteArray positionData;
+
+    fillBytesData(iObj, positionData);
+
+    // contains the connections between the selected view and its corresponding
+    // observed landmarks
+    auto* rcGeometry = createGeometryRenderer(positionData, RC_INDEX_ATTRIBUTE_NAME);
+    // contains the connections between the observed landmarks of the current view
+    // and their corresponding observing view cameras
+    auto* tcGeometry = createGeometryRenderer(positionData, TC_INDEX_ATTRIBUTE_NAME);
+
+    // create separate QEntity objects to have different material colors
+
+    auto* tcEntity = new QEntity(this);
+    tcEntity->addComponent(tcGeometry);
+    tcEntity->addComponent(createMaterial(0, 1, 0, .7f));
+
+    auto* rcEntity = new QEntity(this);
+    rcEntity->addComponent(rcGeometry);
+    rcEntity->addComponent(createMaterial(0, 0, 1, .7f));
+}
+
+void ObservationsEntity::update(const IndexT& viewId, const QVariantMap& viewer2DInfo)
+{
+    QByteArray tcIndexData;
+    QByteArray rcIndexData;
+    size_t tcIndexSize = 0;
+    size_t rcIndexCount = 0;
+
+    const auto& it = _landmarksPerView.find(viewId);
+    if (it != _landmarksPerView.end())
+    {
+        // 2D view bounds
+        const float& scale = viewer2DInfo["scale"].toFloat();
+        const float& x1 = -viewer2DInfo["x"].toFloat() / scale;
+        const float& y1 = -viewer2DInfo["y"].toFloat() / scale;
+        const float& x2 = viewer2DInfo["width"].toFloat() / scale + x1;
+        const float& y2 = viewer2DInfo["height"].toFloat() / scale + y1;
+
+        const auto& totalNbObservations = it->second.first;
+        const auto& totalNbLandmarks = it->second.second.size();
+
+        tcIndexData.resize(static_cast<int>(totalNbObservations * sizeof(uint) * 2));
+        rcIndexData.resize(static_cast<int>(totalNbLandmarks * sizeof(uint) * 2));
+        char* tcIndexIt = tcIndexData.data();
+        uint* rcIndexIt = reinterpret_cast<uint*>(rcIndexData.data());
+
+        const auto& rcVertexPos = _viewId2vertexPos.at(viewId);
+        for (auto& landmarkPerView : it->second.second)
+        {
+            const auto& coords2D = landmarkPerView.observation.x;
+            // if not observed in viewer 2D
+            if (coords2D.x() < x1 || coords2D.x() > x2 || coords2D.y() < y1 || coords2D.y() > y2)
+                continue;
+
+            *rcIndexIt++ = rcVertexPos;
+            *rcIndexIt++ = landmarkPerView.landmarkId;
+            rcIndexCount += 2;
+
+            auto itt = _indexBytesByLandmark.data();
+            std::advance(itt, _landmarkId2IndexRange[landmarkPerView.landmarkId].first * sizeof(uint));
+            const auto& d = _landmarkId2IndexRange[landmarkPerView.landmarkId].second * sizeof(uint);
+            memcpy(tcIndexIt, itt, d);
+            std::advance(tcIndexIt, d);
+            tcIndexSize += d;
+        }
+        tcIndexData.resize(static_cast<int>(tcIndexSize));
+        rcIndexData.resize(static_cast<int>(rcIndexCount * sizeof(uint)));
+    }
+
+    this->findChild<Qt3DRender::QAttribute*>(TC_INDEX_ATTRIBUTE_NAME)->buffer()->setData(tcIndexData);
+    this->findChild<Qt3DRender::QAttribute*>(TC_INDEX_ATTRIBUTE_NAME)
+        ->setCount(static_cast<uint>(tcIndexSize / sizeof(uint)));
+
+    this->findChild<Qt3DRender::QAttribute*>(RC_INDEX_ATTRIBUTE_NAME)->buffer()->setData(rcIndexData);
+    this->findChild<Qt3DRender::QAttribute*>(RC_INDEX_ATTRIBUTE_NAME)->setCount(static_cast<uint>(rcIndexCount));
+}
+
+void ObservationsEntity::fillLandmarksPerViews()
+{
+    for (const auto& landIt : _sfmData.getLandmarks())
+    {
+        for (const auto& obsIt : landIt.second.observations)
+        {
+            IndexT viewId = obsIt.first;
+            auto& [totalNbObservations, landmarksSet] = _landmarksPerView[viewId];
+            totalNbObservations += landIt.second.observations.size();
+            landmarksSet.push_back(LandmarkPerView(landIt.first, landIt.second, obsIt.second));
+        }
+    }
+}
+
+void ObservationsEntity::fillBytesData(const Alembic::Abc::IObject& iObj, QByteArray& positionData)
+{
+     using namespace Alembic::Abc;
+     using namespace Alembic::AbcGeom;
+     using sfmDataIO::AV_UInt32ArraySamplePtr;
+
+     IPoints points(iObj, kWrapExisting);
+     IPointsSchema schema = points.getSchema();
+
+     // -------------- read position data ----------------------
+
+     P3fArraySamplePtr positionsLandmarks = schema.getValue().getPositions();
+     const auto& nLandmarks = positionsLandmarks->size();
+     const auto& nViews = _sfmData.getViews().size();
+     positionData.resize(static_cast<int>((nLandmarks + nViews) * 3 * sizeof(float)));
+     // copy positions of landmarks
+     memcpy(positionData.data(), (const char*)positionsLandmarks->get(), nLandmarks * 3 * sizeof(float));
+     // copy positions of view cameras and construct _viewId2vertexPos
+     {
+          auto* positionsIt = positionData.data();
+          uint viewPosIdx = static_cast<uint>(nLandmarks);
+          // view camera positions are added after landmarks'
+          positionsIt += 3 * sizeof(float) * nLandmarks;
+          for (const auto& viewIt : _sfmData.getViews())
+          {
+             _viewId2vertexPos[viewIt.first] = viewPosIdx++;
+             aliceVision::Vec3f center = _sfmData.getPose(*viewIt.second).getTransform().center().cast<float>();
+             // graphics to open-gl coordinates system
+             center.z() *= -1;
+             center.y() *= -1;
+             memcpy(positionsIt, reinterpret_cast<char*>(center.data()), 3 * sizeof(float));
+             positionsIt += 3 * sizeof(float);
+          }
+     }
+
+     // -------------- read Tc index data ----------------------
+
+     {
+          ICompoundProperty userProps = aliceVision::sfmDataIO::getAbcUserProperties(schema);
+          AV_UInt32ArraySamplePtr sampleVisibilitySize(userProps, "mvg_visibilitySize");
+          AV_UInt32ArraySamplePtr sampleVisibilityViewId(userProps, "mvg_visibilityViewId");
+
+         _indexBytesByLandmark.resize(static_cast<int>(2 * sizeof(uint) * sampleVisibilityViewId.size()));
+         _landmarkId2IndexRange.resize(sampleVisibilityViewId.size());
+         uint* indices = reinterpret_cast<uint*>(_indexBytesByLandmark.data());
+         uint offset = 0;
+         size_t obsGlobalIndex = 0;
+         for (uint point3d_i = 0; point3d_i < sampleVisibilitySize.size(); ++point3d_i)
+         {
+             // Number of observation for this 3d point
+             const size_t visibilitySize = sampleVisibilitySize[point3d_i];
+             const auto& delta = static_cast<uint>(visibilitySize * 2);
+             _landmarkId2IndexRange[point3d_i] = std::pair<uint, uint>(offset, delta);
+             offset += delta;
+             for (size_t obs_i = 0; obs_i < visibilitySize; ++obs_i, ++obsGlobalIndex)
+             {
+                 *indices++ = point3d_i;
+                 *indices++ = _viewId2vertexPos.at(static_cast<IndexT>(sampleVisibilityViewId[obsGlobalIndex]));
+             }
+         }
+     }
+}
+
+QGeometryRenderer* createGeometryRenderer(const QByteArray& positionData, const std::string& indexAttributeName)
+{
+     // create a new geometry renderer
+     auto customMeshRenderer = new QGeometryRenderer;
+     // the corresponding geometry consisting of:
+     // - a position attribute defining the 3D points
+     // - an index attribute defining the connectivity between points
+     auto customGeometry = new QGeometry;
+
+     // mesh
+     customMeshRenderer->setGeometry(customGeometry);
+     customMeshRenderer->setPrimitiveType(QGeometryRenderer::Lines);
+
+     // ------------- 3D points -------------------
+
+     // the vertices buffer
+     auto* vertexDataBuffer = new QBuffer;
+     vertexDataBuffer->setData(positionData);
+     // the position attribute
+     auto* positionAttribute = new QAttribute;
+     positionAttribute->setBuffer(vertexDataBuffer);
+     positionAttribute->setAttributeType(QAttribute::VertexAttribute);
+     positionAttribute->setVertexBaseType(QAttribute::Float);
+     positionAttribute->setVertexSize(3); // space dimension
+     positionAttribute->setByteOffset(0);
+     const auto& nbBytesPerVertex = 3 * sizeof(float);
+     positionAttribute->setByteStride(static_cast<uint>(nbBytesPerVertex));
+     positionAttribute->setCount(static_cast<uint>(positionData.size() / nbBytesPerVertex));
+     positionAttribute->setName(QAttribute::defaultPositionAttributeName());
+     customGeometry->addAttribute(positionAttribute); // add to the geometry
+
+     // ------------- connectivity between 3D points -------------------
+
+     // byte array containing pairs of indices to connected 3D points in poisition attribute
+     QByteArray indexBytes;
+     // the indices buffer
+     auto* indexBuffer = new QBuffer;
+     indexBuffer->setData(indexBytes);
+     // the index attribute
+     auto* indexAttribute = new QAttribute;
+     indexAttribute->setBuffer(indexBuffer);
+     indexAttribute->setAttributeType(QAttribute::IndexAttribute);
+     indexAttribute->setVertexBaseType(QAttribute::UnsignedInt);
+     indexAttribute->setCount(0); // index data not yet available
+     // set name for accessing the attribute and filling data later
+     indexAttribute->setObjectName(QString::fromStdString(indexAttributeName));
+     customGeometry->addAttribute(indexAttribute); // add to the geometry
+
+     return customMeshRenderer;
+}
+
+QMaterial* createMaterial(const float& r, const float& g, const float& b, const float& a)
+{
+     // material for the connections between 3D points
+     auto* material = new Qt3DExtras::QPhongAlphaMaterial;
+     material->setAmbient(QColor::fromRgbF(r, g, b));
+     material->setDiffuse(QColor::fromRgbF(r, g, b));
+     material->setSpecular(QColor::fromRgbF(r, g, b));
+     material->setShininess(0.0f);
+     material->setAlpha(a);
+
+     return material;
+}
+
+} // namespace

--- a/src/qmlAlembic/ObservationsEntity.cpp
+++ b/src/qmlAlembic/ObservationsEntity.cpp
@@ -15,26 +15,6 @@ namespace abcentity
 static const auto& TC_INDEX_ATTRIBUTE_NAME = "Tc-observations indices";
 static const auto& RC_INDEX_ATTRIBUTE_NAME = "Rc-observations indices";
 
-/**
- * @brief encapsulates sufficient and fast retrievable information on a landmark observed by a view
- */
-struct LandmarkPerView
-{
-    LandmarkPerView() = default;
-
-    LandmarkPerView(const IndexT& landmarkId, const sfmData::Landmark& landmark,
-                    const sfmData::Observation& observation)
-        : landmarkId(landmarkId)
-        , landmark(landmark)
-        , observation(observation)
-    {
-    }
-
-    const uint& landmarkId;
-    const sfmData::Landmark& landmark;
-    const sfmData::Observation& observation;
-};
-
 // helper functions
 
 QGeometryRenderer* createGeometryRenderer(const QByteArray& positionData, const std::string& indexAttributeName);

--- a/src/qmlAlembic/ObservationsEntity.hpp
+++ b/src/qmlAlembic/ObservationsEntity.hpp
@@ -15,11 +15,11 @@ struct LandmarkPerView
 {
     LandmarkPerView() = default;
 
-    LandmarkPerView(const IndexT& landmarkId, const sfmData::Landmark& landmark,
-                    const sfmData::Observation& observation)
-        : landmarkId(landmarkId)
-        , landmark(landmark)
-        , observation(observation)
+    LandmarkPerView(const IndexT& landmarkId_, const sfmData::Landmark& landmark_,
+                    const sfmData::Observation& observation_)
+        : landmarkId(landmarkId_)
+        , landmark(landmark_)
+        , observation(observation_)
     {
     }
 

--- a/src/qmlAlembic/ObservationsEntity.hpp
+++ b/src/qmlAlembic/ObservationsEntity.hpp
@@ -17,12 +17,12 @@ public:
     explicit ObservationsEntity(std::string source, Qt3DCore::QNode* parent = nullptr);
     ~ObservationsEntity() override = default;
 
-    void setData(const Alembic::Abc::IObject&);
+    void setData();
     void update(const aliceVision::IndexT& viewId, const QVariantMap& viewer2DInfo);
 
 private:
 
-    void fillBytesData(const Alembic::Abc::IObject& iObj, QByteArray& positionData);
+    void fillBytesData(QByteArray& positionData);
     void fillLandmarksPerViews();
 
     // file path to SfM data

--- a/src/qmlAlembic/ObservationsEntity.hpp
+++ b/src/qmlAlembic/ObservationsEntity.hpp
@@ -3,11 +3,30 @@
 #include "BaseAlembicObject.hpp"
 #include <aliceVision/sfmData/SfMData.hpp>
 
+using namespace aliceVision;
 
 namespace abcentity
 {
 
-struct LandmarkPerView;
+/**
+ * @brief encapsulates sufficient and fast retrievable information on a landmark observed by a view
+ */
+struct LandmarkPerView
+{
+    LandmarkPerView() = default;
+
+    LandmarkPerView(const IndexT& landmarkId, const sfmData::Landmark& landmark,
+                    const sfmData::Observation& observation)
+        : landmarkId(landmarkId)
+        , landmark(landmark)
+        , observation(observation)
+    {
+    }
+
+    const uint& landmarkId;
+    const sfmData::Landmark& landmark;
+    const sfmData::Observation& observation;
+};
 
 class ObservationsEntity : public BaseAlembicObject
 {
@@ -18,7 +37,7 @@ public:
     ~ObservationsEntity() override = default;
 
     void setData();
-    void update(const aliceVision::IndexT& viewId, const QVariantMap& viewer2DInfo);
+    void update(const IndexT& viewId, const QVariantMap& viewer2DInfo);
 
 private:
 
@@ -34,12 +53,12 @@ private:
     // in _indexBytesByLandmark for a landmark
     std::vector<std::pair<uint, uint>> _landmarkId2IndexRange;
     // maps view id to index of the corresponding position for a view camera in position data
-    std::map<aliceVision::IndexT, uint> _viewId2vertexPos;
-    aliceVision::sfmData::SfMData _sfmData;
+    std::map<IndexT, uint> _viewId2vertexPos;
+    sfmData::SfMData _sfmData;
     // maps view id to a pair containing:
     // - the total number of observations of all landmarks observed by this view
     // - a vector of LandmarkPerView structures corresponding to the landmarks observed by this view
-    stl::flat_map<aliceVision::IndexT, std::pair<size_t, std::vector<LandmarkPerView>>> _landmarksPerView;
+    stl::flat_map<IndexT, std::pair<size_t, std::vector<LandmarkPerView>>> _landmarksPerView;
 };
 
 } // namespace

--- a/src/qmlAlembic/ObservationsEntity.hpp
+++ b/src/qmlAlembic/ObservationsEntity.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "BaseAlembicObject.hpp"
+#include <aliceVision/sfmData/SfMData.hpp>
+
+
+namespace abcentity
+{
+
+struct LandmarkPerView;
+
+class ObservationsEntity : public BaseAlembicObject
+{
+    Q_OBJECT
+
+public:
+    explicit ObservationsEntity(std::string source, Qt3DCore::QNode* parent = nullptr);
+    ~ObservationsEntity() override = default;
+
+    void setData(const Alembic::Abc::IObject&);
+    void update(const aliceVision::IndexT& viewId, const QVariantMap& viewer2DInfo);
+
+private:
+
+    void fillBytesData(const Alembic::Abc::IObject& iObj, QByteArray& positionData);
+    void fillLandmarksPerViews();
+
+    // file path to SfM data
+    std::string _source;
+    // contains the indices of vertices in position data used to draw lines
+    // between landmarks and their corresponding obsevations (ordered by landmark)
+    QByteArray _indexBytesByLandmark;
+    // each pair represents the offset position and count of indices (not bytes)
+    // in _indexBytesByLandmark for a landmark
+    std::vector<std::pair<uint, uint>> _landmarkId2IndexRange;
+    // maps view id to index of the corresponding position for a view camera in position data
+    std::map<aliceVision::IndexT, uint> _viewId2vertexPos;
+    aliceVision::sfmData::SfMData _sfmData;
+    // maps view id to a pair containing:
+    // - the total number of observations of all landmarks observed by this view
+    // - a vector of LandmarkPerView structures corresponding to the landmarks observed by this view
+    stl::flat_map<aliceVision::IndexT, std::pair<size_t, std::vector<LandmarkPerView>>> _landmarksPerView;
+};
+
+} // namespace

--- a/src/qmlAlembic/plugin.hpp
+++ b/src/qmlAlembic/plugin.hpp
@@ -22,6 +22,8 @@ public:
                                                         "Cannot create CameraLocatorEntity instances from QML.");
         qmlRegisterUncreatableType<PointCloudEntity>(uri, 2, 0, "PointCloudEntity",
                                                         "Cannot create PointCloudEntity instances from QML.");
+        qmlRegisterUncreatableType<ObservationsEntity>(uri, 2, 0, "ObservationsEntity",
+                                                     "Cannot create ObservationsEntity instances from QML.");
     }
 };
 


### PR DESCRIPTION
Linked to https://github.com/alicevision/Meshroom/pull/2177

- add an option to visualize the landmarks observations
- observed landmarks for current camera + links to cameras observing the same landmarks
- linked to the 2D viewer to zoom on specific landmarks

![landmarks](https://github.com/alicevision/Meshroom/assets/72821992/730d83e1-76cb-499a-a23b-110ec8a54013)