### PR TITLE
Add new SfmDataEntity plugin to use SfMData instead of Alembic

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,15 @@ MTracks {
 
 ```js
 FeaturesViewer {
-    colorOffset: 0
-    describerType: "sift"
-    featureFolder: "/path/to/features/folder"
-    mTracks: tracks
-    viewId: 101245654
-    color: “blue”
-    landmarkColor: “red”
-    displayMode: FeaturesViewer.Points
-    mSfmData: sfmData
+  colorOffset: 0
+  describerType: "sift"
+  featureFolder: "/path/to/features/folder"
+  mTracks: tracks
+  viewId: 101245654
+  color: “blue”
+  landmarkColor: “red”
+  displayMode: FeaturesViewer.Points
+  mSfmData: sfmData
 }
 ```
 
@@ -128,16 +128,29 @@ Scene3D {
 }
 ```
 
- - Create a `AlembicEntity` to display point clouds and cameras in a 3D viewer:
+ - Create a `AlembicEntity` to display .abc point clouds and cameras in a 3D viewer:
 
 ```js
 import AlembicEntity 1.0
 
 Scene3D {
   AlembicEntity {
-    url: "myfile.abc"
+    source: "myfile.abc"
   }
 }
+```
+
+ - Create a `SfmDataEntity` to display point clouds (in .abc, .sfm or .json format) and cameras in a 3D viewer:
+
+```js
+import SfmDataEntity 1.0
+
+Scene3D {
+  SfmDataEntity {
+    source: "/path/to/pointcloud.sfm"
+  }
+}
+
 ```
 
 ### OpenImageIO backend

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 if(BUILD_SFM)
     add_subdirectory(qtAliceVision)
+    add_subdirectory(qmlSfmData)
 endif()
 
 if(BUILD_ALEMBIC)

--- a/src/qmlSfmData/CMakeLists.txt
+++ b/src/qmlSfmData/CMakeLists.txt
@@ -1,0 +1,66 @@
+# Target srcs
+set(PLUGIN_SOURCES
+    IOThread.cpp
+    SfmDataEntity.cpp
+    CameraLocatorEntity.cpp
+    PointCloudEntity.cpp
+    )
+
+set(PLUGIN_HEADERS
+    IOThread.hpp
+    plugin.hpp
+    SfmDataEntity.hpp
+    CameraLocatorEntity.hpp
+    PointCloudEntity.hpp
+    )
+
+
+# Qt module dependency
+find_package(Qt5 COMPONENTS Qml REQUIRED)
+find_package(Qt5 COMPONENTS 3DCore REQUIRED)
+find_package(Qt5 COMPONENTS 3DRender REQUIRED)
+find_package(Qt5 COMPONENTS 3DExtras REQUIRED)
+
+
+
+# Target properties
+add_library(sfmDataEntityQmlPlugin SHARED ${PLUGIN_SOURCES} ${PLUGIN_HEADERS})
+
+if(MSVC)
+    target_compile_options(sfmDataEntityQmlPlugin PUBLIC /W4)
+else()
+    target_compile_options(sfmDataEntityQmlPlugin PUBLIC -Wall -Wextra -Wconversion -Wsign-conversion -Wshadow -Wpedantic)
+endif()
+
+# target_include_directories(sfmDataEntityQmlPlugin
+#     PUBLIC
+#     ${ILMBASE_INCLUDE_DIR}
+#     )
+
+target_link_libraries(sfmDataEntityQmlPlugin
+    PUBLIC
+        Qt5::Core
+        Qt5::Qml
+        Qt5::3DCore
+        Qt5::3DRender
+        aliceVision_sfmDataIO
+        aliceVision_sfm
+        aliceVision_system
+    PRIVATE
+        Qt5::3DExtras
+    )
+
+set_target_properties(sfmDataEntityQmlPlugin
+        PROPERTIES
+        DEBUG_POSTFIX "d"
+        FOLDER "sfmDataEntityQmlPlugin"
+        SOVERSION ${PROJECT_VERSION_MAJOR}
+        VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
+        )
+
+
+# Install settings
+install(FILES "qmldir"
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/qml/SfmDataEntity)
+install(TARGETS sfmDataEntityQmlPlugin
+        DESTINATION "${CMAKE_INSTALL_PREFIX}/qml/SfmDataEntity")

--- a/src/qmlSfmData/CMakeLists.txt
+++ b/src/qmlSfmData/CMakeLists.txt
@@ -4,7 +4,7 @@ set(PLUGIN_SOURCES
     SfmDataEntity.cpp
     CameraLocatorEntity.cpp
     PointCloudEntity.cpp
-    )
+)
 
 set(PLUGIN_HEADERS
     IOThread.hpp
@@ -12,8 +12,7 @@ set(PLUGIN_HEADERS
     SfmDataEntity.hpp
     CameraLocatorEntity.hpp
     PointCloudEntity.hpp
-    )
-
+)
 
 # Qt module dependency
 find_package(Qt5 COMPONENTS Qml REQUIRED)
@@ -21,21 +20,17 @@ find_package(Qt5 COMPONENTS 3DCore REQUIRED)
 find_package(Qt5 COMPONENTS 3DRender REQUIRED)
 find_package(Qt5 COMPONENTS 3DExtras REQUIRED)
 
-
-
 # Target properties
 add_library(sfmDataEntityQmlPlugin SHARED ${PLUGIN_SOURCES} ${PLUGIN_HEADERS})
 
 if(MSVC)
     target_compile_options(sfmDataEntityQmlPlugin PUBLIC /W4)
 else()
-    target_compile_options(sfmDataEntityQmlPlugin PUBLIC -Wall -Wextra -Wconversion -Wsign-conversion -Wshadow -Wpedantic)
+    target_compile_options(sfmDataEntityQmlPlugin
+        PUBLIC
+        -Wall -Wextra -Wconversion -Wsign-conversion -Wshadow -Wpedantic
+    )
 endif()
-
-# target_include_directories(sfmDataEntityQmlPlugin
-#     PUBLIC
-#     ${ILMBASE_INCLUDE_DIR}
-#     )
 
 target_link_libraries(sfmDataEntityQmlPlugin
     PUBLIC
@@ -48,16 +43,15 @@ target_link_libraries(sfmDataEntityQmlPlugin
         aliceVision_system
     PRIVATE
         Qt5::3DExtras
-    )
+)
 
 set_target_properties(sfmDataEntityQmlPlugin
-        PROPERTIES
-        DEBUG_POSTFIX "d"
-        FOLDER "sfmDataEntityQmlPlugin"
-        SOVERSION ${PROJECT_VERSION_MAJOR}
-        VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
-        )
-
+    PROPERTIES
+    DEBUG_POSTFIX "d"
+    FOLDER "sfmDataEntityQmlPlugin"
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
+)
 
 # Install settings
 install(FILES "qmldir"

--- a/src/qmlSfmData/CameraLocatorEntity.cpp
+++ b/src/qmlSfmData/CameraLocatorEntity.cpp
@@ -24,28 +24,27 @@ CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT & viewId, Qt3
 
     // vertices buffer
     QVector<float> points = {
-            // Coord system
-            0.f,  0.f,  0.f,  0.5f,  0.0f,  0.0f, // X
-            0.f,  0.f,  0.f,  0.0f,  -0.5f,  0.0f, // Y
-            0.f,  0.f,  0.f,  0.0f,  0.0f,  -0.5f, // Z
+        // Coord system
+        0.f,  0.f,  0.f,  0.5f,  0.0f,  0.0f,  // X
+        0.f,  0.f,  0.f,  0.0f,  -0.5f,  0.0f,  // Y
+        0.f,  0.f,  0.f,  0.0f,  0.0f,  -0.5f,  // Z
 
-            // Pyramid
-            0.f,  0.f,  0.f,  -0.3f, 0.2f,  -0.3f, // TL
-            0.f,  0.f,  0.f,  -0.3f, -0.2f, -0.3f, // BL
-            0.f,  0.f,  0.f,   0.3f, -0.2f, -0.3f, // BR
-            0.f,  0.f,  0.f,   0.3f,  0.2f, -0.3f, // TR
+        // Pyramid
+        0.f,  0.f,  0.f,  -0.3f, 0.2f,  -0.3f,  // TL
+        0.f,  0.f,  0.f,  -0.3f, -0.2f, -0.3f,  // BL
+        0.f,  0.f,  0.f,   0.3f, -0.2f, -0.3f,  // BR
+        0.f,  0.f,  0.f,   0.3f,  0.2f, -0.3f,  // TR
 
-            // Image plane
-            -0.3f, -0.2f, -0.3f,  -0.3f, 0.2f, -0.3f, // L
-            -0.3f, 0.2f, -0.3f,   0.3f, 0.2f, -0.3f, // B
-            0.3f, 0.2f, -0.3f,   0.3f,  -0.2f, -0.3f, // R
-            0.3f,  -0.2f, -0.3f,  -0.3f,  -0.2f, -0.3f, // T
+        // Image plane
+        -0.3f, -0.2f, -0.3f,  -0.3f, 0.2f, -0.3f,  // L
+        -0.3f, 0.2f, -0.3f,   0.3f, 0.2f, -0.3f,  // B
+        0.3f, 0.2f, -0.3f,   0.3f,  -0.2f, -0.3f,  // R
+        0.3f,  -0.2f, -0.3f,  -0.3f,  -0.2f, -0.3f,  // T
 
-            // Camera Up
-            -0.3f,  0.2f, -0.3f,  0.0f,  0.25f, -0.3f, // L
-            0.3f,  0.2f, -0.3f,  0.0f,  0.25f, -0.3f, // R
-        };
-
+        // Camera Up
+        -0.3f,  0.2f, -0.3f,  0.0f,  0.25f, -0.3f,  // L
+        0.3f,  0.2f, -0.3f,  0.0f,  0.25f, -0.3f,  // R
+    };
 
     QByteArray positionData((const char*)points.data(), points.size() * static_cast<int>(sizeof(float)));
     auto vertexDataBuffer = new QBuffer;
@@ -64,9 +63,9 @@ CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT & viewId, Qt3
     // colors buffer
     QVector<float> colors {
         // Coord system
-        1.f, 0.f, 0.f, 1.f, 0.f, 0.f, // R
-        0.f, 1.f, 0.f, 0.f, 1.f, 0.f, // G
-        0.f, 0.f, 1.f, 0.f, 0.f, 1.f, // B
+        1.f, 0.f, 0.f, 1.f, 0.f, 0.f,  // R
+        0.f, 1.f, 0.f, 0.f, 1.f, 0.f,  // G
+        0.f, 0.f, 1.f, 0.f, 0.f, 1.f,  // B
         // Pyramid
         1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
         1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
@@ -80,7 +79,7 @@ CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT & viewId, Qt3
         // Camera Up direction
         1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
         1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
-        };
+    };
 
     QByteArray colorData((const char*)colors.data(), colors.size() * static_cast<int>(sizeof(float)));
     auto colorDataBuffer = new QBuffer;
@@ -110,7 +109,7 @@ CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT & viewId, Qt3
 
 
 void CameraLocatorEntity::setTransform(const Eigen::Matrix4d & T)
-{   
+{
     Eigen::Matrix4d M;
     M.setIdentity();
     M(1, 1) = -1;
@@ -119,12 +118,19 @@ void CameraLocatorEntity::setTransform(const Eigen::Matrix4d & T)
     Eigen::Matrix4d mat = (M * T * M).inverse();
 
     QMatrix4x4 qmat(
-        static_cast<float>(mat(0, 0)), static_cast<float>(mat(0, 1)), static_cast<float>(mat(0, 2)), static_cast<float>(mat(0, 3)),
-        static_cast<float>(mat(1, 0)), static_cast<float>(mat(1, 1)), static_cast<float>(mat(1, 2)), static_cast<float>(mat(1, 3)),
-        static_cast<float>(mat(2, 0)), static_cast<float>(mat(2, 1)), static_cast<float>(mat(2, 2)), static_cast<float>(mat(2, 3)),
-        static_cast<float>(mat(3, 0)), static_cast<float>(mat(3, 1)), static_cast<float>(mat(3, 2)), static_cast<float>(mat(3, 3)));
+        static_cast<float>(mat(0, 0)), static_cast<float>(mat(0, 1)),
+        static_cast<float>(mat(0, 2)), static_cast<float>(mat(0, 3)),
+
+        static_cast<float>(mat(1, 0)), static_cast<float>(mat(1, 1)),
+        static_cast<float>(mat(1, 2)), static_cast<float>(mat(1, 3)),
+
+        static_cast<float>(mat(2, 0)), static_cast<float>(mat(2, 1)),
+        static_cast<float>(mat(2, 2)), static_cast<float>(mat(2, 3)),
+
+        static_cast<float>(mat(3, 0)), static_cast<float>(mat(3, 1)),
+        static_cast<float>(mat(3, 2)), static_cast<float>(mat(3, 3)));
 
     _transform->setMatrix(qmat);
 }
 
-}
+}  // namespace sfmdataentity

--- a/src/qmlSfmData/CameraLocatorEntity.cpp
+++ b/src/qmlSfmData/CameraLocatorEntity.cpp
@@ -1,0 +1,130 @@
+#include "CameraLocatorEntity.hpp"
+
+#include <Qt3DRender/QGeometryRenderer>
+#include <Qt3DRender/QAttribute>
+#include <Qt3DRender/QBuffer>
+#include <Qt3DRender/QObjectPicker>
+#include <Qt3DCore/QTransform>
+
+namespace sfmdataentity
+{
+
+CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT & viewId, Qt3DCore::QNode* parent)
+    : Qt3DCore::QEntity(parent),
+      _viewId(viewId)
+{
+    _transform = new Qt3DCore::QTransform;
+    addComponent(_transform);
+
+    using namespace Qt3DRender;
+
+    // create a new geometry renderer
+    auto customMeshRenderer = new QGeometryRenderer;
+    auto customGeometry = new QGeometry;
+
+    // vertices buffer
+    QVector<float> points = {
+            // Coord system
+            0.f,  0.f,  0.f,  0.5f,  0.0f,  0.0f, // X
+            0.f,  0.f,  0.f,  0.0f,  -0.5f,  0.0f, // Y
+            0.f,  0.f,  0.f,  0.0f,  0.0f,  -0.5f, // Z
+
+            // Pyramid
+            0.f,  0.f,  0.f,  -0.3f, 0.2f,  -0.3f, // TL
+            0.f,  0.f,  0.f,  -0.3f, -0.2f, -0.3f, // BL
+            0.f,  0.f,  0.f,   0.3f, -0.2f, -0.3f, // BR
+            0.f,  0.f,  0.f,   0.3f,  0.2f, -0.3f, // TR
+
+            // Image plane
+            -0.3f, -0.2f, -0.3f,  -0.3f, 0.2f, -0.3f, // L
+            -0.3f, 0.2f, -0.3f,   0.3f, 0.2f, -0.3f, // B
+            0.3f, 0.2f, -0.3f,   0.3f,  -0.2f, -0.3f, // R
+            0.3f,  -0.2f, -0.3f,  -0.3f,  -0.2f, -0.3f, // T
+
+            // Camera Up
+            -0.3f,  0.2f, -0.3f,  0.0f,  0.25f, -0.3f, // L
+            0.3f,  0.2f, -0.3f,  0.0f,  0.25f, -0.3f, // R
+        };
+
+
+    QByteArray positionData((const char*)points.data(), points.size() * static_cast<int>(sizeof(float)));
+    auto vertexDataBuffer = new QBuffer;
+    vertexDataBuffer->setData(positionData);
+    auto positionAttribute = new QAttribute;
+    positionAttribute->setAttributeType(QAttribute::VertexAttribute);
+    positionAttribute->setBuffer(vertexDataBuffer);
+    positionAttribute->setVertexBaseType(QAttribute::Float);
+    positionAttribute->setVertexSize(3);
+    positionAttribute->setByteOffset(0);
+    positionAttribute->setByteStride(3 * sizeof(float));
+    positionAttribute->setCount(static_cast<uint>(points.size() / 3));
+    positionAttribute->setName(QAttribute::defaultPositionAttributeName());
+    customGeometry->addAttribute(positionAttribute);
+
+    // colors buffer
+    QVector<float> colors {
+        // Coord system
+        1.f, 0.f, 0.f, 1.f, 0.f, 0.f, // R
+        0.f, 1.f, 0.f, 0.f, 1.f, 0.f, // G
+        0.f, 0.f, 1.f, 0.f, 0.f, 1.f, // B
+        // Pyramid
+        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+        // Image Plane
+        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+        // Camera Up direction
+        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+        };
+
+    QByteArray colorData((const char*)colors.data(), colors.size() * static_cast<int>(sizeof(float)));
+    auto colorDataBuffer = new QBuffer;
+    colorDataBuffer->setData(colorData);
+    auto colorAttribute = new QAttribute;
+    colorAttribute->setAttributeType(QAttribute::VertexAttribute);
+    colorAttribute->setBuffer(colorDataBuffer);
+    colorAttribute->setVertexBaseType(QAttribute::Float);
+    colorAttribute->setVertexSize(3);
+    colorAttribute->setByteOffset(0);
+    colorAttribute->setByteStride(3 * sizeof(float));
+    colorAttribute->setCount(static_cast<uint>(colors.size() / 3));
+    colorAttribute->setName(QAttribute::defaultColorAttributeName());
+    customGeometry->addAttribute(colorAttribute);
+
+    // geometry renderer settings
+    customMeshRenderer->setInstanceCount(1);
+    customMeshRenderer->setFirstVertex(0);
+    customMeshRenderer->setFirstInstance(0);
+    customMeshRenderer->setPrimitiveType(QGeometryRenderer::Lines);
+    customMeshRenderer->setGeometry(customGeometry);
+    customMeshRenderer->setVertexCount(points.size() / 3);
+
+    // add components
+    addComponent(customMeshRenderer);
+}
+
+
+void CameraLocatorEntity::setTransform(const Eigen::Matrix4d & T)
+{   
+    Eigen::Matrix4d M;
+    M.setIdentity();
+    M(1, 1) = -1;
+    M(2, 2) = -1;
+
+    Eigen::Matrix4d mat = (M * T * M).inverse();
+
+    QMatrix4x4 qmat(
+        static_cast<float>(mat(0, 0)), static_cast<float>(mat(0, 1)), static_cast<float>(mat(0, 2)), static_cast<float>(mat(0, 3)),
+        static_cast<float>(mat(1, 0)), static_cast<float>(mat(1, 1)), static_cast<float>(mat(1, 2)), static_cast<float>(mat(1, 3)),
+        static_cast<float>(mat(2, 0)), static_cast<float>(mat(2, 1)), static_cast<float>(mat(2, 2)), static_cast<float>(mat(2, 3)),
+        static_cast<float>(mat(3, 0)), static_cast<float>(mat(3, 1)), static_cast<float>(mat(3, 2)), static_cast<float>(mat(3, 3)));
+
+    _transform->setMatrix(qmat);
+}
+
+}

--- a/src/qmlSfmData/CameraLocatorEntity.hpp
+++ b/src/qmlSfmData/CameraLocatorEntity.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QEntity>
+#include <Qt3DCore/QTransform>
+#include <Eigen/Dense>
+#include <aliceVision/types.hpp>
+
+namespace sfmdataentity
+{
+
+class CameraLocatorEntity : public Qt3DCore::QEntity
+{
+    Q_OBJECT
+
+    Q_PROPERTY(quint32 viewId MEMBER _viewId NOTIFY viewIdChanged)
+
+public:
+    explicit CameraLocatorEntity(const aliceVision::IndexT & viewId, Qt3DCore::QNode* = nullptr);
+    ~CameraLocatorEntity() override = default;
+    
+    void setTransform(const Eigen::Matrix4d & );
+
+public:
+    Q_SIGNAL void viewIdChanged();
+
+private:
+    Qt3DCore::QTransform* _transform;
+    aliceVision::IndexT _viewId;
+};
+
+} // namespace

--- a/src/qmlSfmData/CameraLocatorEntity.hpp
+++ b/src/qmlSfmData/CameraLocatorEntity.hpp
@@ -17,10 +17,9 @@ class CameraLocatorEntity : public Qt3DCore::QEntity
 public:
     explicit CameraLocatorEntity(const aliceVision::IndexT & viewId, Qt3DCore::QNode* = nullptr);
     ~CameraLocatorEntity() override = default;
-    
-    void setTransform(const Eigen::Matrix4d & );
 
-public:
+    void setTransform(const Eigen::Matrix4d &);
+
     Q_SIGNAL void viewIdChanged();
 
 private:
@@ -28,4 +27,4 @@ private:
     aliceVision::IndexT _viewId;
 };
 
-} // namespace
+}  // namespace sfmdataentity

--- a/src/qmlSfmData/IOThread.cpp
+++ b/src/qmlSfmData/IOThread.cpp
@@ -1,0 +1,42 @@
+#include "IOThread.hpp"
+#include <QFile>
+#include <QDebug>
+
+namespace sfmdataentity
+{
+
+void IOThread::read(const QUrl& source)
+{
+    _source = source;
+    start();
+}
+
+void IOThread::run()
+{
+    // ensure file exists and is valid
+    if(!_source.isValid() || !QFile::exists(_source.toLocalFile()))
+        return;
+    QMutexLocker lock(&_mutex);
+    
+
+    if (!aliceVision::sfmDataIO::Load(_sfmData, _source.toLocalFile().toStdString(), aliceVision::sfmDataIO::ESfMData(aliceVision::sfmDataIO::ESfMData::VIEWS | aliceVision::sfmDataIO::ESfMData::INTRINSICS | aliceVision::sfmDataIO::ESfMData::EXTRINSICS |aliceVision::sfmDataIO::ESfMData::STRUCTURE)))
+    {
+        qDebug() << "[QtAliceVision] Failed to load sfmData: " << _source << ".";
+    }
+}
+
+void IOThread::clear()
+{
+    QMutexLocker lock(&_mutex);
+
+    _sfmData = aliceVision::sfmData::SfMData();
+}
+
+const aliceVision::sfmData::SfMData & IOThread::getSfmData() const
+{
+    // mutex is mutable and can be locked in const methods
+    QMutexLocker lock(&_mutex);
+    return _sfmData;
+}
+
+}

--- a/src/qmlSfmData/IOThread.cpp
+++ b/src/qmlSfmData/IOThread.cpp
@@ -14,12 +14,15 @@ void IOThread::read(const QUrl& source)
 void IOThread::run()
 {
     // ensure file exists and is valid
-    if(!_source.isValid() || !QFile::exists(_source.toLocalFile()))
+    if (!_source.isValid() || !QFile::exists(_source.toLocalFile()))
         return;
-    QMutexLocker lock(&_mutex);
-    
 
-    if (!aliceVision::sfmDataIO::Load(_sfmData, _source.toLocalFile().toStdString(), aliceVision::sfmDataIO::ESfMData(aliceVision::sfmDataIO::ESfMData::VIEWS | aliceVision::sfmDataIO::ESfMData::INTRINSICS | aliceVision::sfmDataIO::ESfMData::EXTRINSICS |aliceVision::sfmDataIO::ESfMData::STRUCTURE)))
+    QMutexLocker lock(&_mutex);
+    if (!aliceVision::sfmDataIO::Load(_sfmData, _source.toLocalFile().toStdString(),
+                                      aliceVision::sfmDataIO::ESfMData(aliceVision::sfmDataIO::ESfMData::VIEWS |
+                                                                       aliceVision::sfmDataIO::ESfMData::INTRINSICS |
+                                                                       aliceVision::sfmDataIO::ESfMData::EXTRINSICS |
+                                                                       aliceVision::sfmDataIO::ESfMData::STRUCTURE)))
     {
         qDebug() << "[QtAliceVision] Failed to load sfmData: " << _source << ".";
     }
@@ -28,7 +31,6 @@ void IOThread::run()
 void IOThread::clear()
 {
     QMutexLocker lock(&_mutex);
-
     _sfmData = aliceVision::sfmData::SfMData();
 }
 
@@ -39,4 +41,4 @@ const aliceVision::sfmData::SfMData & IOThread::getSfmData() const
     return _sfmData;
 }
 
-}
+}  // namespace sfmdataentity

--- a/src/qmlSfmData/IOThread.hpp
+++ b/src/qmlSfmData/IOThread.hpp
@@ -20,13 +20,13 @@ class IOThread : public QThread
 public:
     /// Read the given source. Starts the thread main loop.
     void read(const QUrl& source);
-    
+
     /// Thread main loop.
     void run() override;
-    
+
     /// Reset internal members.
     void clear();
-    
+
     /// Get the sfmData
     const aliceVision::sfmData::SfMData & getSfmData() const;
 
@@ -36,4 +36,4 @@ private:
     aliceVision::sfmData::SfMData _sfmData;
 };
 
-}
+}  // namespace sfmdataentity

--- a/src/qmlSfmData/IOThread.hpp
+++ b/src/qmlSfmData/IOThread.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <QThread>
+#include <QUrl>
+#include <QMutex>
+
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+
+
+namespace sfmdataentity
+{
+
+/**
+ * @brief Handle Alembic IO in a separate thread.
+ */
+class IOThread : public QThread
+{
+    Q_OBJECT
+
+public:
+    /// Read the given source. Starts the thread main loop.
+    void read(const QUrl& source);
+    
+    /// Thread main loop.
+    void run() override;
+    
+    /// Reset internal members.
+    void clear();
+    
+    /// Get the sfmData
+    const aliceVision::sfmData::SfMData & getSfmData() const;
+
+private:
+    QUrl _source;
+    mutable QMutex _mutex;
+    aliceVision::sfmData::SfMData _sfmData;
+};
+
+}

--- a/src/qmlSfmData/PointCloudEntity.cpp
+++ b/src/qmlSfmData/PointCloudEntity.cpp
@@ -21,7 +21,6 @@ void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks & landmarks
     auto customMeshRenderer = new QGeometryRenderer;
     auto customGeometry = new QGeometry;
 
-    
     std::vector<float> points;
     std::vector<float> colors;
     for (const auto & l : landmarks)
@@ -35,9 +34,7 @@ void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks & landmarks
         colors.push_back(static_cast<float>(l.second.rgb(2) / 255.0f));
     }
 
-    int npoints = landmarks.size();
-
-    
+    int npoints = static_cast<int>(landmarks.size());
 
     // vertices buffer
     QByteArray positionData((const char*)points.data(), npoints * 3 * static_cast<int>(sizeof(float)));
@@ -57,9 +54,8 @@ void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks & landmarks
 
     // read color data
     auto colorDataBuffer = new QBuffer;
-    QByteArray colorData((const char*)colors.data(), static_cast<int>(npoints * 3 * sizeof(float)));
+    QByteArray colorData((const char*)colors.data(), npoints * 3 * static_cast<int>(sizeof(float)));
     colorDataBuffer->setData(colorData);
-
 
     // colors buffer
     auto colorAttribute = new QAttribute;
@@ -85,5 +81,4 @@ void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks & landmarks
     addComponent(customMeshRenderer);
 }
 
-
-} // namespace
+}  // namespace sfmdataentity

--- a/src/qmlSfmData/PointCloudEntity.cpp
+++ b/src/qmlSfmData/PointCloudEntity.cpp
@@ -30,9 +30,9 @@ void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks & landmarks
         points.push_back(static_cast<float>(- l.second.X(1)));
         points.push_back(static_cast<float>(- l.second.X(2)));
 
-        colors.push_back(static_cast<float>(l.second.rgb(0)));
-        colors.push_back(static_cast<float>(l.second.rgb(1)));
-        colors.push_back(static_cast<float>(l.second.rgb(2)));
+        colors.push_back(static_cast<float>(l.second.rgb(0) / 255.0f));
+        colors.push_back(static_cast<float>(l.second.rgb(1) / 255.0f));
+        colors.push_back(static_cast<float>(l.second.rgb(2) / 255.0f));
     }
 
     int npoints = landmarks.size();

--- a/src/qmlSfmData/PointCloudEntity.cpp
+++ b/src/qmlSfmData/PointCloudEntity.cpp
@@ -1,0 +1,89 @@
+#include "PointCloudEntity.hpp"
+
+#include <Qt3DRender/QGeometryRenderer>
+#include <Qt3DRender/QAttribute>
+#include <Qt3DRender/QBuffer>
+#include <Qt3DCore/QTransform>
+
+namespace sfmdataentity
+{
+
+PointCloudEntity::PointCloudEntity(Qt3DCore::QNode* parent)
+    : Qt3DCore::QEntity(parent)
+{
+}
+
+void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks & landmarks)
+{
+    using namespace Qt3DRender;
+
+    // create a new geometry renderer
+    auto customMeshRenderer = new QGeometryRenderer;
+    auto customGeometry = new QGeometry;
+
+    
+    std::vector<float> points;
+    std::vector<float> colors;
+    for (const auto & l : landmarks)
+    {
+        points.push_back(static_cast<float>(l.second.X(0)));
+        points.push_back(static_cast<float>(- l.second.X(1)));
+        points.push_back(static_cast<float>(- l.second.X(2)));
+
+        colors.push_back(static_cast<float>(l.second.rgb(0)));
+        colors.push_back(static_cast<float>(l.second.rgb(1)));
+        colors.push_back(static_cast<float>(l.second.rgb(2)));
+    }
+
+    int npoints = landmarks.size();
+
+    
+
+    // vertices buffer
+    QByteArray positionData((const char*)points.data(), npoints * 3 * static_cast<int>(sizeof(float)));
+    auto vertexDataBuffer = new QBuffer;
+    vertexDataBuffer->setData(positionData);
+    auto positionAttribute = new QAttribute;
+    positionAttribute->setAttributeType(QAttribute::VertexAttribute);
+    positionAttribute->setBuffer(vertexDataBuffer);
+    positionAttribute->setVertexBaseType(QAttribute::Float);
+    positionAttribute->setVertexSize(3);
+    positionAttribute->setByteOffset(0);
+    positionAttribute->setByteStride(3 * sizeof(float));
+    positionAttribute->setCount(static_cast<uint>(npoints));
+    positionAttribute->setName(QAttribute::defaultPositionAttributeName());
+    customGeometry->addAttribute(positionAttribute);
+    customGeometry->setBoundingVolumePositionAttribute(positionAttribute);
+
+    // read color data
+    auto colorDataBuffer = new QBuffer;
+    QByteArray colorData((const char*)colors.data(), static_cast<int>(npoints * 3 * sizeof(float)));
+    colorDataBuffer->setData(colorData);
+
+
+    // colors buffer
+    auto colorAttribute = new QAttribute;
+    colorAttribute->setAttributeType(QAttribute::VertexAttribute);
+    colorAttribute->setBuffer(colorDataBuffer);
+    colorAttribute->setVertexBaseType(QAttribute::Float);
+    colorAttribute->setVertexSize(3);
+    colorAttribute->setByteOffset(0);
+    colorAttribute->setByteStride(3 * sizeof(float));
+    colorAttribute->setCount(static_cast<uint>(npoints));
+    colorAttribute->setName(QAttribute::defaultColorAttributeName());
+    customGeometry->addAttribute(colorAttribute);
+
+    // geometry renderer settings
+    customMeshRenderer->setInstanceCount(1);
+    customMeshRenderer->setFirstVertex(0);
+    customMeshRenderer->setFirstInstance(0);
+    customMeshRenderer->setPrimitiveType(QGeometryRenderer::Points);
+    customMeshRenderer->setGeometry(customGeometry);
+    customMeshRenderer->setVertexCount(npoints);
+
+    // add components
+    addComponent(customMeshRenderer);
+}
+
+
+} // namespace

--- a/src/qmlSfmData/PointCloudEntity.hpp
+++ b/src/qmlSfmData/PointCloudEntity.hpp
@@ -14,9 +14,7 @@ class PointCloudEntity : public Qt3DCore::QEntity
 public:
     explicit PointCloudEntity(Qt3DCore::QNode* = nullptr);
     ~PointCloudEntity() override = default;
-
-public:
     void setData(const aliceVision::sfmData::Landmarks & landmarks);
 };
 
-} // namespace
+}  // namespace sfmdataentity

--- a/src/qmlSfmData/PointCloudEntity.hpp
+++ b/src/qmlSfmData/PointCloudEntity.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QEntity>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+
+
+namespace sfmdataentity
+{
+
+class PointCloudEntity : public Qt3DCore::QEntity
+{
+    Q_OBJECT
+
+public:
+    explicit PointCloudEntity(Qt3DCore::QNode* = nullptr);
+    ~PointCloudEntity() override = default;
+
+public:
+    void setData(const aliceVision::sfmData::Landmarks & landmarks);
+};
+
+} // namespace

--- a/src/qmlSfmData/SfmDataEntity.cpp
+++ b/src/qmlSfmData/SfmDataEntity.cpp
@@ -1,0 +1,203 @@
+#include "SfmDataEntity.hpp"
+#include "IOThread.hpp"
+
+#include "CameraLocatorEntity.hpp"
+#include "PointCloudEntity.hpp"
+
+#include <aliceVision/geometry/Pose3.hpp>
+
+#include <Qt3DRender/QEffect>
+#include <Qt3DRender/QTechnique>
+#include <Qt3DRender/QRenderPass>
+#include <Qt3DRender/QShaderProgram>
+#include <Qt3DRender/QObjectPicker>
+#include <Qt3DRender/QPickEvent>
+#include <Qt3DRender/QDebugOverlay>
+#include <Qt3DExtras/QPerVertexColorMaterial>
+#include <QFile>
+
+
+namespace sfmdataentity
+{
+
+SfmDataEntity::SfmDataEntity(Qt3DCore::QNode* parent)
+    : Qt3DCore::QEntity(parent)
+    , _pointSizeParameter(new Qt3DRender::QParameter)
+    , _ioThread(new IOThread())
+{
+    connect(_ioThread.get(), &IOThread::finished, this, &SfmDataEntity::onIOThreadFinished);
+    createMaterials();
+}
+
+void SfmDataEntity::setSource(const QUrl& value)
+{
+    if(_source == value)
+        return;
+    _source = value;
+    loadSfmData();
+    Q_EMIT sourceChanged();
+}
+
+void SfmDataEntity::setPointSize(const float& value)
+{
+    if(_pointSize == value)
+    {
+        return;
+    }
+
+    _pointSize = value;
+    _pointSizeParameter->setValue(value);
+    _cloudMaterial->setEnabled(_pointSize > 0.0f);
+
+    Q_EMIT pointSizeChanged();
+}
+
+void SfmDataEntity::setLocatorScale(const float& value)
+{
+    if(_locatorScale == value)
+    {
+        return;
+    }
+
+    _locatorScale = value;
+    scaleLocators();
+
+    Q_EMIT locatorScaleChanged();
+}
+
+void SfmDataEntity::scaleLocators() const
+{
+    for (auto* entity : _cameras)
+    {
+        for(auto* transform : entity->findChildren<Qt3DCore::QTransform*>())
+        {
+            transform->setScale(_locatorScale);
+        }
+    }
+}
+
+void SfmDataEntity::createMaterials()
+{
+    using namespace Qt3DRender;
+    using namespace Qt3DExtras;
+
+    _cloudMaterial = new QMaterial(this);
+    _cameraMaterial = new QPerVertexColorMaterial(this);
+
+    // configure cloud material
+    auto effect = new QEffect;
+    auto technique = new QTechnique;
+    auto renderPass = new QRenderPass;
+    auto shaderProgram = new QShaderProgram;
+
+    shaderProgram->setVertexShaderCode(R"(#version 130
+    in vec3 vertexPosition;
+    in vec3 vertexColor;
+    out vec3 color;
+    uniform mat4 mvp;
+    uniform mat4 projectionMatrix;
+    uniform mat4 viewportMatrix;
+    uniform float pointSize;
+    void main()
+    {
+        color = vertexColor;
+        gl_Position = mvp * vec4(vertexPosition, 1.0);
+        gl_PointSize = max(viewportMatrix[1][1] * projectionMatrix[1][1] * pointSize / gl_Position.w, 1.0);
+    }
+    )");
+
+    // set fragment shader
+    shaderProgram->setFragmentShaderCode(R"(#version 130
+        in vec3 color;
+        out vec4 fragColor;
+        void main(void)
+        {
+            fragColor = vec4(color, 1.0);
+        }
+    )");
+
+    // add a pointSize uniform
+    _pointSizeParameter->setName("pointSize");
+    _pointSizeParameter->setValue(_pointSize);
+    _cloudMaterial->addParameter(_pointSizeParameter);
+
+    // build the material
+    renderPass->setShaderProgram(shaderProgram);
+    technique->addRenderPass(renderPass);
+    effect->addTechnique(technique);
+    _cloudMaterial->setEffect(effect);
+}
+
+void SfmDataEntity::clear()
+{
+    // clear entity (remove direct children & all components)
+    auto entities = findChildren<QEntity*>(QString(), Qt::FindDirectChildrenOnly);
+    for(auto entity : entities)
+    {
+        entity->setParent((QNode*)nullptr);
+        entity->deleteLater();
+    }
+    for(auto& component : components())
+    {
+        removeComponent(component);
+    }
+    
+    _cameras.clear();
+    _pointClouds.clear();
+}
+
+// private
+void SfmDataEntity::loadSfmData()
+{
+    clear();
+
+    if(_source.isEmpty())
+    {
+        setStatus(SfmDataEntity::None);
+        return;
+    }
+
+    setStatus(SfmDataEntity::Loading);
+
+    _ioThread->read(_source);
+}
+
+void SfmDataEntity::onIOThreadFinished()
+{
+    const auto& sfmData = _ioThread->getSfmData();
+
+    Qt3DCore::QEntity * root = new Qt3DCore::QEntity(this);
+
+    {
+        PointCloudEntity* entity = new PointCloudEntity(root);
+        entity->setData(sfmData.getLandmarks());
+        entity->addComponent(_cloudMaterial);
+    }
+
+    for (const auto & pv : sfmData.getViews())
+    {
+        if(!sfmData.isPoseAndIntrinsicDefined(pv.second.get()))
+        {
+            continue;
+        }
+
+        CameraLocatorEntity* entity = new CameraLocatorEntity(pv.first, root);
+        entity->addComponent(_cameraMaterial);
+        entity->setTransform(sfmData.getPoses().at(pv.second->getPoseId()).getTransform().getHomogeneous());
+        entity->setObjectName(std::to_string(pv.first).c_str());
+    }
+
+    scaleLocators();
+
+    _cameras = findChildren<CameraLocatorEntity*>();
+    _pointClouds = findChildren<PointCloudEntity*>();
+    
+    setStatus(SfmDataEntity::Ready);
+
+    _ioThread->clear();
+    
+    Q_EMIT pointCloudsChanged();
+    Q_EMIT camerasChanged();
+}
+
+} // namespace

--- a/src/qmlSfmData/SfmDataEntity.cpp
+++ b/src/qmlSfmData/SfmDataEntity.cpp
@@ -187,10 +187,10 @@ void SfmDataEntity::onIOThreadFinished()
         entity->setObjectName(std::to_string(pv.first).c_str());
     }
 
-    scaleLocators();
-
     _cameras = findChildren<CameraLocatorEntity*>();
     _pointClouds = findChildren<PointCloudEntity*>();
+
+    scaleLocators();
     
     setStatus(SfmDataEntity::Ready);
 

--- a/src/qmlSfmData/SfmDataEntity.cpp
+++ b/src/qmlSfmData/SfmDataEntity.cpp
@@ -31,7 +31,7 @@ SfmDataEntity::SfmDataEntity(Qt3DCore::QNode* parent)
 
 void SfmDataEntity::setSource(const QUrl& value)
 {
-    if(_source == value)
+    if (_source == value)
         return;
     _source = value;
     loadSfmData();
@@ -40,7 +40,7 @@ void SfmDataEntity::setSource(const QUrl& value)
 
 void SfmDataEntity::setPointSize(const float& value)
 {
-    if(_pointSize == value)
+    if (_pointSize == value)
     {
         return;
     }
@@ -54,7 +54,7 @@ void SfmDataEntity::setPointSize(const float& value)
 
 void SfmDataEntity::setLocatorScale(const float& value)
 {
-    if(_locatorScale == value)
+    if (_locatorScale == value)
     {
         return;
     }
@@ -69,7 +69,7 @@ void SfmDataEntity::scaleLocators() const
 {
     for (auto* entity : _cameras)
     {
-        for(auto* transform : entity->findChildren<Qt3DCore::QTransform*>())
+        for (auto* transform : entity->findChildren<Qt3DCore::QTransform*>())
         {
             transform->setScale(_locatorScale);
         }
@@ -132,16 +132,16 @@ void SfmDataEntity::clear()
 {
     // clear entity (remove direct children & all components)
     auto entities = findChildren<QEntity*>(QString(), Qt::FindDirectChildrenOnly);
-    for(auto entity : entities)
+    for (auto entity : entities)
     {
         entity->setParent((QNode*)nullptr);
         entity->deleteLater();
     }
-    for(auto& component : components())
+    for (auto& component : components())
     {
         removeComponent(component);
     }
-    
+
     _cameras.clear();
     _pointClouds.clear();
 }
@@ -151,7 +151,7 @@ void SfmDataEntity::loadSfmData()
 {
     clear();
 
-    if(_source.isEmpty())
+    if (_source.isEmpty())
     {
         setStatus(SfmDataEntity::None);
         return;
@@ -176,7 +176,7 @@ void SfmDataEntity::onIOThreadFinished()
 
     for (const auto & pv : sfmData.getViews())
     {
-        if(!sfmData.isPoseAndIntrinsicDefined(pv.second.get()))
+        if (!sfmData.isPoseAndIntrinsicDefined(pv.second.get()))
         {
             continue;
         }
@@ -191,13 +191,13 @@ void SfmDataEntity::onIOThreadFinished()
     _pointClouds = findChildren<PointCloudEntity*>();
 
     scaleLocators();
-    
+
     setStatus(SfmDataEntity::Ready);
 
     _ioThread->clear();
-    
+
     Q_EMIT pointCloudsChanged();
     Q_EMIT camerasChanged();
 }
 
-} // namespace
+}  // namespace sfmdataentity

--- a/src/qmlSfmData/SfmDataEntity.hpp
+++ b/src/qmlSfmData/SfmDataEntity.hpp
@@ -51,29 +51,12 @@ public:
     Status status() const { return _status; }
 
     void setStatus(Status status) {
-        if(status == _status)
+        if (status == _status)
             return;
         _status = status;
         Q_EMIT statusChanged(_status);
     }
 
-private:
-    /// Delete all child entities/components
-    void clear();
-    void loadSfmData();
-    void createMaterials();
-
-    QQmlListProperty<CameraLocatorEntity> cameras() 
-    {
-        return {this, &_cameras};
-    }
-
-    QQmlListProperty<PointCloudEntity> pointClouds() 
-    {
-        return {this, &_pointClouds};
-    }
-
-public:
     Q_SIGNAL void sourceChanged();
     Q_SIGNAL void camerasChanged();
     Q_SIGNAL void pointSizeChanged();
@@ -90,6 +73,21 @@ protected:
     void onIOThreadFinished();
 
 private:
+    /// Delete all child entities/components
+    void clear();
+    void loadSfmData();
+    void createMaterials();
+
+    QQmlListProperty<CameraLocatorEntity> cameras()
+    {
+        return {this, &_cameras};
+    }
+
+    QQmlListProperty<PointCloudEntity> pointClouds()
+    {
+        return {this, &_pointClouds};
+    }
+
     Status _status = SfmDataEntity::None;
     QUrl _source;
     bool _skipHidden = false;
@@ -103,4 +101,4 @@ private:
     std::unique_ptr<IOThread> _ioThread;
 };
 
-} // namespace
+}  // namespace sfmdataentity

--- a/src/qmlSfmData/SfmDataEntity.hpp
+++ b/src/qmlSfmData/SfmDataEntity.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <QEntity>
+#include <QUrl>
+
+#include <Qt3DCore/QTransform>
+#include <Qt3DRender/QParameter>
+#include <Qt3DRender/QMaterial>
+#include <QQmlListProperty>
+
+#include <iostream>
+
+namespace sfmdataentity
+{
+class PointCloudEntity;
+class CameraLocatorEntity;
+class IOThread;
+
+class SfmDataEntity : public Qt3DCore::QEntity
+{
+    Q_OBJECT
+    Q_PROPERTY(QUrl source READ source WRITE setSource NOTIFY sourceChanged)
+    Q_PROPERTY(bool skipHidden MEMBER _skipHidden NOTIFY skipHiddenChanged)
+    Q_PROPERTY(float pointSize READ pointSize WRITE setPointSize NOTIFY pointSizeChanged)
+    Q_PROPERTY(float locatorScale READ locatorScale WRITE setLocatorScale NOTIFY locatorScaleChanged)
+    Q_PROPERTY(QQmlListProperty<sfmdataentity::CameraLocatorEntity> cameras READ cameras NOTIFY camerasChanged)
+    Q_PROPERTY(QQmlListProperty<sfmdataentity::PointCloudEntity> pointClouds READ pointClouds NOTIFY pointCloudsChanged)
+
+    Q_PROPERTY(Status status READ status NOTIFY statusChanged)
+
+public:
+    // Identical to SceneLoader.Status
+    enum Status {
+            None = 0,
+            Loading,
+            Ready,
+            Error
+    };
+    Q_ENUM(Status)
+
+    explicit SfmDataEntity(Qt3DCore::QNode* = nullptr);
+    ~SfmDataEntity() override = default;
+
+    Q_SLOT const QUrl& source() const { return _source; }
+    Q_SLOT float pointSize() const { return _pointSize; }
+    Q_SLOT float locatorScale() const { return _locatorScale; }
+    Q_SLOT void setSource(const QUrl& source);
+    Q_SLOT void setPointSize(const float& value);
+    Q_SLOT void setLocatorScale(const float& value);
+
+    Status status() const { return _status; }
+
+    void setStatus(Status status) {
+        if(status == _status)
+            return;
+        _status = status;
+        Q_EMIT statusChanged(_status);
+    }
+
+private:
+    /// Delete all child entities/components
+    void clear();
+    void loadSfmData();
+    void createMaterials();
+
+    QQmlListProperty<CameraLocatorEntity> cameras() 
+    {
+        return {this, &_cameras};
+    }
+
+    QQmlListProperty<PointCloudEntity> pointClouds() 
+    {
+        return {this, &_pointClouds};
+    }
+
+public:
+    Q_SIGNAL void sourceChanged();
+    Q_SIGNAL void camerasChanged();
+    Q_SIGNAL void pointSizeChanged();
+    Q_SIGNAL void pointCloudsChanged();
+    Q_SIGNAL void locatorScaleChanged();
+    Q_SIGNAL void objectPicked(Qt3DCore::QTransform* transform);
+    Q_SIGNAL void statusChanged(Status status);
+    Q_SIGNAL void skipHiddenChanged();
+
+protected:
+    /// Scale child locators
+    void scaleLocators() const;
+
+    void onIOThreadFinished();
+
+private:
+    Status _status = SfmDataEntity::None;
+    QUrl _source;
+    bool _skipHidden = false;
+    float _pointSize = 0.5f;
+    float _locatorScale = 1.0f;
+    Qt3DRender::QParameter* _pointSizeParameter;
+    Qt3DRender::QMaterial* _cloudMaterial;
+    Qt3DRender::QMaterial* _cameraMaterial;
+    QList<CameraLocatorEntity*> _cameras;
+    QList<PointCloudEntity*> _pointClouds;
+    std::unique_ptr<IOThread> _ioThread;
+};
+
+} // namespace

--- a/src/qmlSfmData/plugin.hpp
+++ b/src/qmlSfmData/plugin.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QtQml>
+#include <QQmlExtensionPlugin>
+
+namespace sfmdataentity
+{
+
+class sfmDataEntityQmlPlugin : public QQmlExtensionPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "sfmDataEntity.qmlPlugin")
+
+public:
+    void initializeEngine(QQmlEngine*, const char*) override {}
+    void registerTypes(const char* uri) override
+    {
+        Q_ASSERT(uri == QLatin1String("SfmDataEntity"));
+        
+        qmlRegisterType<SfmDataEntity>(uri, 1, 0, "SfmDataEntity");
+        qmlRegisterUncreatableType<CameraLocatorEntity>(uri, 1, 0, "CameraLocatorEntity", "Cannot create CameraLocatorEntity instances from QML.");
+        qmlRegisterUncreatableType<PointCloudEntity>(uri, 1, 0, "PointCloudEntity", "Cannot create PointCloudEntity instances from QML.");
+    }
+};
+
+} // namespace

--- a/src/qmlSfmData/plugin.hpp
+++ b/src/qmlSfmData/plugin.hpp
@@ -16,11 +16,13 @@ public:
     void registerTypes(const char* uri) override
     {
         Q_ASSERT(uri == QLatin1String("SfmDataEntity"));
-        
+
         qmlRegisterType<SfmDataEntity>(uri, 1, 0, "SfmDataEntity");
-        qmlRegisterUncreatableType<CameraLocatorEntity>(uri, 1, 0, "CameraLocatorEntity", "Cannot create CameraLocatorEntity instances from QML.");
-        qmlRegisterUncreatableType<PointCloudEntity>(uri, 1, 0, "PointCloudEntity", "Cannot create PointCloudEntity instances from QML.");
+        qmlRegisterUncreatableType<CameraLocatorEntity>(uri, 1, 0, "CameraLocatorEntity",
+                                                        "Cannot create CameraLocatorEntity instances from QML.");
+        qmlRegisterUncreatableType<PointCloudEntity>(uri, 1, 0, "PointCloudEntity",
+                                                     "Cannot create PointCloudEntity instances from QML.");
     }
 };
 
-} // namespace
+}  // namespace sfmdataentity

--- a/src/qmlSfmData/qmldir
+++ b/src/qmlSfmData/qmldir
@@ -1,0 +1,3 @@
+module SfmDataEntity
+
+plugin sfmDataEntityQmlPlugin


### PR DESCRIPTION
Replace QmlAlembic to use SfmData instead of Alembic library directly.

- Enable display of 3d content of SfmData

Related Meshroom pull request: https://github.com/alicevision/Meshroom/pull/2208