### PR TITLE
[qmlSfmData] Handle exceptions and do not attempt to load invalid files

### DIFF
--- a/src/qmlSfmData/IOThread.cpp
+++ b/src/qmlSfmData/IOThread.cpp
@@ -18,13 +18,20 @@ void IOThread::run()
         return;
 
     QMutexLocker lock(&_mutex);
-    if (!aliceVision::sfmDataIO::Load(_sfmData, _source.toLocalFile().toStdString(),
-                                      aliceVision::sfmDataIO::ESfMData(aliceVision::sfmDataIO::ESfMData::VIEWS |
-                                                                       aliceVision::sfmDataIO::ESfMData::INTRINSICS |
-                                                                       aliceVision::sfmDataIO::ESfMData::EXTRINSICS |
-                                                                       aliceVision::sfmDataIO::ESfMData::STRUCTURE)))
+    try
     {
-        qDebug() << "[QtAliceVision] Failed to load sfmData: " << _source << ".";
+        if (!aliceVision::sfmDataIO::Load(_sfmData, _source.toLocalFile().toStdString(),
+                                        aliceVision::sfmDataIO::ESfMData(aliceVision::sfmDataIO::ESfMData::VIEWS |
+                                                                        aliceVision::sfmDataIO::ESfMData::INTRINSICS |
+                                                                        aliceVision::sfmDataIO::ESfMData::EXTRINSICS |
+                                                                        aliceVision::sfmDataIO::ESfMData::STRUCTURE)))
+        {
+            qWarning() << "[QmlSfmData] Failed to load SfMData: " << _source << ".";
+        }
+    }
+    catch (const std::exception &e)
+    {
+        qCritical() << "[QmlSfmData] Error while loading the SfMData: " << e.what();
     }
 }
 

--- a/src/qmlSfmData/PointCloudEntity.cpp
+++ b/src/qmlSfmData/PointCloudEntity.cpp
@@ -37,7 +37,7 @@ void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks & landmarks
     int npoints = static_cast<int>(landmarks.size());
 
     // vertices buffer
-    QByteArray positionData((const char*)points.data(), npoints * 3 * static_cast<int>(sizeof(float)));
+    QByteArray positionData(reinterpret_cast<const char*>(points.data()), npoints * 3 * static_cast<int>(sizeof(float)));
     auto vertexDataBuffer = new QBuffer;
     vertexDataBuffer->setData(positionData);
     auto positionAttribute = new QAttribute;
@@ -54,7 +54,7 @@ void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks & landmarks
 
     // read color data
     auto colorDataBuffer = new QBuffer;
-    QByteArray colorData((const char*)colors.data(), npoints * 3 * static_cast<int>(sizeof(float)));
+    QByteArray colorData(reinterpret_cast<const char*>(colors.data()), npoints * 3 * static_cast<int>(sizeof(float)));
     colorDataBuffer->setData(colorData);
 
     // colors buffer


### PR DESCRIPTION
This PR addresses 3 issues that stem from #45:
1. If a file that contained something other than an SfMData was provided to the SfmDataEntity, an unhandled exception was raised and led to a crash. That exception is now caught, and an error message printed.
2. If a file that contained either no or an empty SfMData file was provided, the SfmDataEntity was still attempting to create all the 3D components to display it, and the status was always set to `Ready` no matter what. With this PR, if the SfMData remains uninitialized (that might be the case if an exception from (1) is thrown), no 3D component is created and the status is set to `Error`. 
3. If a valid SfMData file contains no 3D information, the behaviour was the same as in (2), and the SfmDataEntity ended up loading and setting everything up although there was nothing to display. The lack of 3D info is now detected prior to creating and setting up all the 3D components. The status is also set to `Error`. 

This relates to aliceVision/Meshroom#2230.