### PR TITLE
Reformat with clang

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,28 +1,70 @@
----
-IndentWidth: 4
-TabWidth: 4
-UseTab: Never
-ColumnLimit: 120
-AllowShortFunctionsOnASingleLine: Inline
+BasedOnStyle: Mozilla
+AlignTrailingComments: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: false
-BreakConstructorInitializersBeforeComma: true
-IndentCaseLabels: true
-BreakBeforeBraces: Allman
-NamespaceIndentation: None
-MaxEmptyLinesToKeep: 1
-KeepEmptyLinesAtTheStartOfBlocks: true
-PointerAlignment: Left
-SpaceBeforeParens: ControlStatements
-SpaceBeforeAssignmentOperators: true
-SpacesInParentheses: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakTemplateDeclarations: true
-Standard: Cpp11
-AccessModifierOffset: -4
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeInheritanceComma: false
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+ColumnLimit: 150
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+IncludeBlocks: Regroup
+IndentCaseLabels: true
+IndentPPDirectives: BeforeHash
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+Language: Cpp
+PackConstructorInitializers: Never
+PointerAlignment: Left
+ReflowComments: true
+SpaceAfterLogicalNot: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpacesBeforeTrailingComments: 2
+SpaceInEmptyParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: "c++17"
 IncludeCategories:
   - Regex:           '^".*"'
     Priority:        1
   - Regex:           '^<aliceVision/.*>'
     Priority:        2
-  - Regex:           '^<.*>'
+  - Regex:           '^<boost/.*>'
     Priority:        3
-SortIncludes: true
+  - Regex:           '^<.*\..*>'
+    Priority:        4
+SortIncludes: false

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# Reformat all plugins with latest clang-format rules
+a1969780d11ba0505b6ec99ddedf80e1917616ab
+# [qmlSfmData] Clean-up: Fix warnings and harmonize code
+acdea1b81afdfa7308d638f556d7ea4860a7f7f6
+# Clean-up: Remove trailing spaces
+74cfbfba88e2e26f3f1341f0aaa8a266196a1876
+# [DepthMapEntity] Remove trailing white spaces
+21a9bf2f258aeb15c6b1bba0d9bb7e431224fb35
+# Clean-up: Improve readability
+edc2d3135e38b9ce25216335f1b90c6b2f39e907
+# Clean-up: Remove trailing spaces
+f60668eb5c3d5b5684ab3c6168e45661bacf0ce4

--- a/src/depthMapEntity/DepthMapEntity.cpp
+++ b/src/depthMapEntity/DepthMapEntity.cpp
@@ -28,13 +28,12 @@
 
 using namespace aliceVision;
 
-namespace depthMapEntity
-{
+namespace depthMapEntity {
 
 DepthMapEntity::DepthMapEntity(Qt3DCore::QNode* parent)
-    : Qt3DCore::QEntity(parent)
-    , _displayMode(DisplayMode::Unknown)
-    , _pointSizeParameter(new Qt3DRender::QParameter)
+  : Qt3DCore::QEntity(parent),
+    _displayMode(DisplayMode::Unknown),
+    _pointSizeParameter(new Qt3DRender::QParameter)
 {
     qDebug() << "[DepthMapEntity] DepthMapEntity";
     createMaterials();
@@ -59,18 +58,16 @@ void DepthMapEntity::setSource(const QUrl& value)
     if (filename.contains("depthMap"))
     {
         _depthMapSource = _source;
-        _simMapSource =
-            QUrl::fromLocalFile(QFileInfo(fileInfo.dir(), filename.replace("depthMap", "simMap")).filePath());
+        _simMapSource = QUrl::fromLocalFile(QFileInfo(fileInfo.dir(), filename.replace("depthMap", "simMap")).filePath());
     }
     else if (filename.contains("simMap"))
     {
         _simMapSource = _source;
-        _depthMapSource =
-            QUrl::fromLocalFile(QFileInfo(fileInfo.dir(), filename.replace("simMap", "depthMap")).filePath());
+        _depthMapSource = QUrl::fromLocalFile(QFileInfo(fileInfo.dir(), filename.replace("simMap", "depthMap")).filePath());
     }
     else
     {
-        qWarning () << "[DepthMapEntity] Source filename must contain depthMap or simMap: " << filename;
+        qWarning() << "[DepthMapEntity] Source filename must contain depthMap or simMap: " << filename;
         _status = DepthMapEntity::Error;
         return;
     }
@@ -237,9 +234,12 @@ void DepthMapEntity::loadDepthMap()
     const std::string depthMapPath = _depthMapSource.toLocalFile().toStdString();
     qDebug() << "[DepthMapEntity] Load depth map: " << _depthMapSource.toLocalFile();
     image::Image<float> depthMap;
-    try {
+    try
+    {
         image::readImage(depthMapPath, depthMap, image::EImageColorSpace::LINEAR);
-    } catch (const std::runtime_error& error) {
+    }
+    catch (const std::runtime_error& error)
+    {
         qCritical() << "[DepthMapEntity] Could not load depth map:" << error.what();
         _status = DepthMapEntity::Error;
         return;
@@ -260,30 +260,26 @@ void DepthMapEntity::loadDepthMap()
         _status = DepthMapEntity::Error;
         return;
     }
-    
-    qDebug() << "[DepthMapEntity] CArr: "
-        << " nvalues: " << cParam->nvalues()
-        << ", type: " << cParam->type().c_str()
-        << ", basetype: " << cParam->type().basetype
-        << ", aggregate: " << cParam->type().aggregate
-        << ", vecsemantics: " << cParam->type().vecsemantics
-        << ", arraylen: " << cParam->type().arraylen
-        ;
 
-    if(cParam->type().aggregate != oiio::TypeDesc::AGGREGATE::VEC3)
+    qDebug() << "[DepthMapEntity] CArr: "
+             << " nvalues: " << cParam->nvalues() << ", type: " << cParam->type().c_str() << ", basetype: " << cParam->type().basetype
+             << ", aggregate: " << cParam->type().aggregate << ", vecsemantics: " << cParam->type().vecsemantics
+             << ", arraylen: " << cParam->type().arraylen;
+
+    if (cParam->type().aggregate != oiio::TypeDesc::AGGREGATE::VEC3)
     {
         qWarning() << "[DepthMapEntity] Metadata CArr: Type error (aggregate: " << cParam->type().aggregate << ")";
         _status = DepthMapEntity::Error;
         return;
     }
-    if(cParam->type().basetype == oiio::TypeDesc::BASETYPE::DOUBLE)
+    if (cParam->type().basetype == oiio::TypeDesc::BASETYPE::DOUBLE)
     {
         std::copy_n(static_cast<const double*>(cParam->data()), 9, CArr.m);
     }
-    else if(cParam->type().basetype == oiio::TypeDesc::BASETYPE::FLOAT)
+    else if (cParam->type().basetype == oiio::TypeDesc::BASETYPE::FLOAT)
     {
         const float* d = static_cast<const float*>(cParam->data());
-        for(int i = 0; i < 9; ++i)
+        for (int i = 0; i < 9; ++i)
         {
             CArr.m[i] = d[i];
         }
@@ -296,8 +292,7 @@ void DepthMapEntity::loadDepthMap()
     }
 
     Matrix3x3 iCamArr;
-    oiio::ParamValue* icParam =
-        inSpec.find_attribute("AliceVision:iCamArr");
+    oiio::ParamValue* icParam = inSpec.find_attribute("AliceVision:iCamArr");
 
     if (!icParam)
     {
@@ -307,27 +302,23 @@ void DepthMapEntity::loadDepthMap()
     }
 
     qDebug() << "[DepthMapEntity] iCamArr: "
-        << " nvalues: " << icParam->nvalues()
-        << ", type: " << icParam->type().c_str()
-        << ", basetype: " << icParam->type().basetype
-        << ", aggregate: " << icParam->type().aggregate
-        << ", vecsemantics: " << icParam->type().vecsemantics
-        << ", arraylen: " << icParam->type().arraylen
-        ;
-    if(icParam->type().aggregate != oiio::TypeDesc::AGGREGATE::MATRIX33)
+             << " nvalues: " << icParam->nvalues() << ", type: " << icParam->type().c_str() << ", basetype: " << icParam->type().basetype
+             << ", aggregate: " << icParam->type().aggregate << ", vecsemantics: " << icParam->type().vecsemantics
+             << ", arraylen: " << icParam->type().arraylen;
+    if (icParam->type().aggregate != oiio::TypeDesc::AGGREGATE::MATRIX33)
     {
         qWarning() << "[DepthMapEntity] Metadata iCamArr: Type error (aggregate: " << icParam->type().aggregate << ")";
         _status = DepthMapEntity::Error;
         return;
     }
-    if(icParam->type().basetype == oiio::TypeDesc::BASETYPE::DOUBLE)
+    if (icParam->type().basetype == oiio::TypeDesc::BASETYPE::DOUBLE)
     {
         std::copy_n(static_cast<const double*>(icParam->data()), 9, iCamArr.m);
     }
-    else if(icParam->type().basetype == oiio::TypeDesc::BASETYPE::FLOAT)
+    else if (icParam->type().basetype == oiio::TypeDesc::BASETYPE::FLOAT)
     {
         const float* d = static_cast<const float*>(icParam->data());
-        for(int i = 0; i < 9; ++i)
+        for (int i = 0; i < 9; ++i)
         {
             iCamArr.m[i] = d[i];
         }
@@ -346,9 +337,12 @@ void DepthMapEntity::loadDepthMap()
     {
         const std::string simMapPath = _simMapSource.toLocalFile().toStdString();
         qDebug() << "[DepthMapEntity] Load sim map: " << _simMapSource.toLocalFile();
-        try {
+        try
+        {
             image::readImage(simMapPath, simMap, image::EImageColorSpace::LINEAR);
-        } catch (const std::runtime_error& error) {
+        }
+        catch (const std::runtime_error& error)
+        {
             qWarning() << "[DepthMapEntity] Sim map could not be loaded:" << error.what();
         }
     }
@@ -377,8 +371,7 @@ void DepthMapEntity::loadDepthMap()
             if (!std::isfinite(depthValue) || depthValue <= 0.f)
                 continue;
 
-            Point3d p =
-                CArr + (iCamArr * Point2d(static_cast<double>(x), static_cast<double>(y))).normalize() * depthValue;
+            Point3d p = CArr + (iCamArr * Point2d(static_cast<double>(x), static_cast<double>(y))).normalize() * depthValue;
             Vec3f position(static_cast<float>(p.x), static_cast<float>(-p.y), static_cast<float>(-p.z));
 
             indexPerPixel[static_cast<std::size_t>(y * depthMap.Width() + x)] = static_cast<int>(positions.size());
@@ -458,13 +451,11 @@ void DepthMapEntity::loadDepthMap()
     }
 
     QBuffer* vertexBuffer = new QBuffer;
-    QByteArray trianglesData(reinterpret_cast<const char*>(&triangles[0]),
-                             static_cast<int>(triangles.size() * sizeof(Vec3f)));
+    QByteArray trianglesData(reinterpret_cast<const char*>(&triangles[0]), static_cast<int>(triangles.size() * sizeof(Vec3f)));
     vertexBuffer->setData(trianglesData);
 
     QBuffer* normalBuffer = new QBuffer;
-    QByteArray normalsData(reinterpret_cast<const char*>(&normals[0]),
-                           static_cast<int>(normals.size() * sizeof(Vec3f)));
+    QByteArray normalsData(reinterpret_cast<const char*>(&normals[0]), static_cast<int>(normals.size() * sizeof(Vec3f)));
     normalBuffer->setData(normalsData);
 
     QAttribute* positionAttribute = new QAttribute(this);
@@ -501,13 +492,11 @@ void DepthMapEntity::loadDepthMap()
 
     // read color data
     QBuffer* colorDataBuffer = new QBuffer;
-    QByteArray colorData(reinterpret_cast<const char*>(colorsFlat[0].data()),
-                         static_cast<int>(colorsFlat.size() * 3 * sizeof(float)));
+    QByteArray colorData(reinterpret_cast<const char*>(colorsFlat[0].data()), static_cast<int>(colorsFlat.size() * 3 * sizeof(float)));
     colorDataBuffer->setData(colorData);
 
     QAttribute* colorAttribute = new QAttribute;
-    qDebug() << "[DepthMapEntity] Qt3DRender::QAttribute::defaultColorAttributeName(): "
-             << Qt3DRender::QAttribute::defaultColorAttributeName();
+    qDebug() << "[DepthMapEntity] Qt3DRender::QAttribute::defaultColorAttributeName(): " << Qt3DRender::QAttribute::defaultColorAttributeName();
     colorAttribute->setName(Qt3DRender::QAttribute::defaultColorAttributeName());
     colorAttribute->setAttributeType(QAttribute::VertexAttribute);
     colorAttribute->setBuffer(colorDataBuffer);
@@ -530,4 +519,4 @@ void DepthMapEntity::loadDepthMap()
     qDebug() << "[DepthMapEntity] Mesh Renderer added";
 }
 
-} // namespace depthMapEntity
+}  // namespace depthMapEntity

--- a/src/depthMapEntity/DepthMapEntity.hpp
+++ b/src/depthMapEntity/DepthMapEntity.hpp
@@ -10,8 +10,7 @@
 #include <Qt3DRender/QMaterial>
 #include <Qt3DRender/QParameter>
 
-namespace depthMapEntity
-{
+namespace depthMapEntity {
 
 class DepthMapEntity : public Qt3DCore::QEntity
 {
@@ -24,7 +23,7 @@ class DepthMapEntity : public Qt3DCore::QEntity
     Q_PROPERTY(bool displayColor READ displayColor WRITE setDisplayColor NOTIFY displayColorChanged)
     Q_PROPERTY(float pointSize READ pointSize WRITE setPointSize NOTIFY pointSizeChanged)
 
-public:
+  public:
     // Identical to SceneLoader.Status
     enum Status
     {
@@ -45,7 +44,7 @@ public:
         Unknown
     };
 
-public:
+  public:
     Q_SLOT const QUrl& source() const { return _source; }
     Q_SLOT void setSource(const QUrl&);
 
@@ -68,19 +67,19 @@ public:
     Q_SLOT float pointSize() const { return _pointSize; }
     Q_SLOT void setPointSize(const float& value);
 
-private:
+  private:
     void loadDepthMap();
     void createMaterials();
     void updateMaterial();
 
-public:
+  public:
     Q_SIGNAL void sourceChanged();
     Q_SIGNAL void statusChanged(Status status);
     Q_SIGNAL void displayModeChanged();
     Q_SIGNAL void displayColorChanged();
     Q_SIGNAL void pointSizeChanged();
 
-private:
+  private:
     Status _status = DepthMapEntity::None;
     QUrl _source;
     QUrl _depthMapSource;
@@ -95,4 +94,4 @@ private:
     Qt3DRender::QMaterial* _currentMaterial = nullptr;
     Qt3DRender::QGeometryRenderer* _meshRenderer = nullptr;
 };
-} // namespace depthMapEntity
+}  // namespace depthMapEntity

--- a/src/depthMapEntity/plugin.hpp
+++ b/src/depthMapEntity/plugin.hpp
@@ -5,15 +5,14 @@
 #include <QtQml/QQmlExtensionPlugin>
 #include <QtQml/QtQml>
 
-namespace depthMapEntity
-{
+namespace depthMapEntity {
 
 class DepthMapEntityPlugin : public QQmlExtensionPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "depthMapEntity.qmlPlugin")
 
-public:
+  public:
     void initializeEngine(QQmlEngine* engine, const char* uri) override
     {
         // Fix "unused parameter" warnings; should be replaced by [[maybe_unused]] when C++17 is supported
@@ -26,4 +25,4 @@ public:
         qmlRegisterType<DepthMapEntity>(uri, 2, 1, "DepthMapEntity");
     }
 };
-} // namespace depthMapEntity
+}  // namespace depthMapEntity

--- a/src/qmlSfmData/CameraLocatorEntity.cpp
+++ b/src/qmlSfmData/CameraLocatorEntity.cpp
@@ -6,12 +6,11 @@
 #include <Qt3DRender/QObjectPicker>
 #include <Qt3DCore/QTransform>
 
-namespace sfmdataentity
-{
+namespace sfmdataentity {
 
-CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT & viewId, Qt3DCore::QNode* parent)
-    : Qt3DCore::QEntity(parent),
-      _viewId(viewId)
+CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT& viewId, Qt3DCore::QNode* parent)
+  : Qt3DCore::QEntity(parent),
+    _viewId(viewId)
 {
     _transform = new Qt3DCore::QTransform;
     addComponent(_transform);
@@ -24,26 +23,91 @@ CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT & viewId, Qt3
 
     // vertices buffer
     QVector<float> points = {
-        // Coord system
-        0.f,  0.f,  0.f,  0.5f,  0.0f,  0.0f,  // X
-        0.f,  0.f,  0.f,  0.0f,  -0.5f,  0.0f,  // Y
-        0.f,  0.f,  0.f,  0.0f,  0.0f,  -0.5f,  // Z
+      // Coord system
+      0.f,
+      0.f,
+      0.f,
+      0.5f,
+      0.0f,
+      0.0f,  // X
+      0.f,
+      0.f,
+      0.f,
+      0.0f,
+      -0.5f,
+      0.0f,  // Y
+      0.f,
+      0.f,
+      0.f,
+      0.0f,
+      0.0f,
+      -0.5f,  // Z
 
-        // Pyramid
-        0.f,  0.f,  0.f,  -0.3f, 0.2f,  -0.3f,  // TL
-        0.f,  0.f,  0.f,  -0.3f, -0.2f, -0.3f,  // BL
-        0.f,  0.f,  0.f,   0.3f, -0.2f, -0.3f,  // BR
-        0.f,  0.f,  0.f,   0.3f,  0.2f, -0.3f,  // TR
+      // Pyramid
+      0.f,
+      0.f,
+      0.f,
+      -0.3f,
+      0.2f,
+      -0.3f,  // TL
+      0.f,
+      0.f,
+      0.f,
+      -0.3f,
+      -0.2f,
+      -0.3f,  // BL
+      0.f,
+      0.f,
+      0.f,
+      0.3f,
+      -0.2f,
+      -0.3f,  // BR
+      0.f,
+      0.f,
+      0.f,
+      0.3f,
+      0.2f,
+      -0.3f,  // TR
 
-        // Image plane
-        -0.3f, -0.2f, -0.3f,  -0.3f, 0.2f, -0.3f,  // L
-        -0.3f, 0.2f, -0.3f,   0.3f, 0.2f, -0.3f,  // B
-        0.3f, 0.2f, -0.3f,   0.3f,  -0.2f, -0.3f,  // R
-        0.3f,  -0.2f, -0.3f,  -0.3f,  -0.2f, -0.3f,  // T
+      // Image plane
+      -0.3f,
+      -0.2f,
+      -0.3f,
+      -0.3f,
+      0.2f,
+      -0.3f,  // L
+      -0.3f,
+      0.2f,
+      -0.3f,
+      0.3f,
+      0.2f,
+      -0.3f,  // B
+      0.3f,
+      0.2f,
+      -0.3f,
+      0.3f,
+      -0.2f,
+      -0.3f,  // R
+      0.3f,
+      -0.2f,
+      -0.3f,
+      -0.3f,
+      -0.2f,
+      -0.3f,  // T
 
-        // Camera Up
-        -0.3f,  0.2f, -0.3f,  0.0f,  0.25f, -0.3f,  // L
-        0.3f,  0.2f, -0.3f,  0.0f,  0.25f, -0.3f,  // R
+      // Camera Up
+      -0.3f,
+      0.2f,
+      -0.3f,
+      0.0f,
+      0.25f,
+      -0.3f,  // L
+      0.3f,
+      0.2f,
+      -0.3f,
+      0.0f,
+      0.25f,
+      -0.3f,  // R
     };
 
     QByteArray positionData((const char*)points.data(), points.size() * static_cast<int>(sizeof(float)));
@@ -61,24 +125,89 @@ CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT & viewId, Qt3
     customGeometry->addAttribute(positionAttribute);
 
     // colors buffer
-    QVector<float> colors {
-        // Coord system
-        1.f, 0.f, 0.f, 1.f, 0.f, 0.f,  // R
-        0.f, 1.f, 0.f, 0.f, 1.f, 0.f,  // G
-        0.f, 0.f, 1.f, 0.f, 0.f, 1.f,  // B
-        // Pyramid
-        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
-        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
-        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
-        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
-        // Image Plane
-        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
-        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
-        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
-        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
-        // Camera Up direction
-        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
-        1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+    QVector<float> colors{
+      // Coord system
+      1.f,
+      0.f,
+      0.f,
+      1.f,
+      0.f,
+      0.f,  // R
+      0.f,
+      1.f,
+      0.f,
+      0.f,
+      1.f,
+      0.f,  // G
+      0.f,
+      0.f,
+      1.f,
+      0.f,
+      0.f,
+      1.f,  // B
+      // Pyramid
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      // Image Plane
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      // Camera Up direction
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
+      1.f,
     };
 
     QByteArray colorData((const char*)colors.data(), colors.size() * static_cast<int>(sizeof(float)));
@@ -107,8 +236,7 @@ CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT & viewId, Qt3
     addComponent(customMeshRenderer);
 }
 
-
-void CameraLocatorEntity::setTransform(const Eigen::Matrix4d & T)
+void CameraLocatorEntity::setTransform(const Eigen::Matrix4d& T)
 {
     Eigen::Matrix4d M;
     M.setIdentity();
@@ -117,18 +245,25 @@ void CameraLocatorEntity::setTransform(const Eigen::Matrix4d & T)
 
     Eigen::Matrix4d mat = (M * T * M).inverse();
 
-    QMatrix4x4 qmat(
-        static_cast<float>(mat(0, 0)), static_cast<float>(mat(0, 1)),
-        static_cast<float>(mat(0, 2)), static_cast<float>(mat(0, 3)),
+    QMatrix4x4 qmat(static_cast<float>(mat(0, 0)),
+                    static_cast<float>(mat(0, 1)),
+                    static_cast<float>(mat(0, 2)),
+                    static_cast<float>(mat(0, 3)),
 
-        static_cast<float>(mat(1, 0)), static_cast<float>(mat(1, 1)),
-        static_cast<float>(mat(1, 2)), static_cast<float>(mat(1, 3)),
+                    static_cast<float>(mat(1, 0)),
+                    static_cast<float>(mat(1, 1)),
+                    static_cast<float>(mat(1, 2)),
+                    static_cast<float>(mat(1, 3)),
 
-        static_cast<float>(mat(2, 0)), static_cast<float>(mat(2, 1)),
-        static_cast<float>(mat(2, 2)), static_cast<float>(mat(2, 3)),
+                    static_cast<float>(mat(2, 0)),
+                    static_cast<float>(mat(2, 1)),
+                    static_cast<float>(mat(2, 2)),
+                    static_cast<float>(mat(2, 3)),
 
-        static_cast<float>(mat(3, 0)), static_cast<float>(mat(3, 1)),
-        static_cast<float>(mat(3, 2)), static_cast<float>(mat(3, 3)));
+                    static_cast<float>(mat(3, 0)),
+                    static_cast<float>(mat(3, 1)),
+                    static_cast<float>(mat(3, 2)),
+                    static_cast<float>(mat(3, 3)));
 
     _transform->setMatrix(qmat);
 }

--- a/src/qmlSfmData/CameraLocatorEntity.hpp
+++ b/src/qmlSfmData/CameraLocatorEntity.hpp
@@ -5,8 +5,7 @@
 #include <Eigen/Dense>
 #include <aliceVision/types.hpp>
 
-namespace sfmdataentity
-{
+namespace sfmdataentity {
 
 class CameraLocatorEntity : public Qt3DCore::QEntity
 {
@@ -14,15 +13,15 @@ class CameraLocatorEntity : public Qt3DCore::QEntity
 
     Q_PROPERTY(quint32 viewId MEMBER _viewId NOTIFY viewIdChanged)
 
-public:
-    explicit CameraLocatorEntity(const aliceVision::IndexT & viewId, Qt3DCore::QNode* = nullptr);
+  public:
+    explicit CameraLocatorEntity(const aliceVision::IndexT& viewId, Qt3DCore::QNode* = nullptr);
     ~CameraLocatorEntity() override = default;
 
-    void setTransform(const Eigen::Matrix4d &);
+    void setTransform(const Eigen::Matrix4d&);
 
     Q_SIGNAL void viewIdChanged();
 
-private:
+  private:
     Qt3DCore::QTransform* _transform;
     aliceVision::IndexT _viewId;
 };

--- a/src/qmlSfmData/IOThread.cpp
+++ b/src/qmlSfmData/IOThread.cpp
@@ -2,8 +2,7 @@
 #include <QFile>
 #include <QDebug>
 
-namespace sfmdataentity
-{
+namespace sfmdataentity {
 
 void IOThread::read(const QUrl& source)
 {
@@ -20,16 +19,16 @@ void IOThread::run()
     QMutexLocker lock(&_mutex);
     try
     {
-        if (!aliceVision::sfmDataIO::Load(_sfmData, _source.toLocalFile().toStdString(),
-                                        aliceVision::sfmDataIO::ESfMData(aliceVision::sfmDataIO::ESfMData::VIEWS |
-                                                                        aliceVision::sfmDataIO::ESfMData::INTRINSICS |
-                                                                        aliceVision::sfmDataIO::ESfMData::EXTRINSICS |
-                                                                        aliceVision::sfmDataIO::ESfMData::STRUCTURE)))
+        if (!aliceVision::sfmDataIO::Load(
+              _sfmData,
+              _source.toLocalFile().toStdString(),
+              aliceVision::sfmDataIO::ESfMData(aliceVision::sfmDataIO::ESfMData::VIEWS | aliceVision::sfmDataIO::ESfMData::INTRINSICS |
+                                               aliceVision::sfmDataIO::ESfMData::EXTRINSICS | aliceVision::sfmDataIO::ESfMData::STRUCTURE)))
         {
             qWarning() << "[QmlSfmData] Failed to load SfMData: " << _source << ".";
         }
     }
-    catch (const std::exception &e)
+    catch (const std::exception& e)
     {
         qCritical() << "[QmlSfmData] Error while loading the SfMData: " << e.what();
     }
@@ -41,7 +40,7 @@ void IOThread::clear()
     _sfmData = aliceVision::sfmData::SfMData();
 }
 
-const aliceVision::sfmData::SfMData & IOThread::getSfmData() const
+const aliceVision::sfmData::SfMData& IOThread::getSfmData() const
 {
     // mutex is mutable and can be locked in const methods
     QMutexLocker lock(&_mutex);

--- a/src/qmlSfmData/IOThread.hpp
+++ b/src/qmlSfmData/IOThread.hpp
@@ -6,9 +6,7 @@
 
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 
-
-namespace sfmdataentity
-{
+namespace sfmdataentity {
 
 /**
  * @brief Handle Alembic IO in a separate thread.
@@ -17,7 +15,7 @@ class IOThread : public QThread
 {
     Q_OBJECT
 
-public:
+  public:
     /// Read the given source. Starts the thread main loop.
     void read(const QUrl& source);
 
@@ -28,9 +26,9 @@ public:
     void clear();
 
     /// Get the sfmData
-    const aliceVision::sfmData::SfMData & getSfmData() const;
+    const aliceVision::sfmData::SfMData& getSfmData() const;
 
-private:
+  private:
     QUrl _source;
     mutable QMutex _mutex;
     aliceVision::sfmData::SfMData _sfmData;

--- a/src/qmlSfmData/PointCloudEntity.cpp
+++ b/src/qmlSfmData/PointCloudEntity.cpp
@@ -5,15 +5,13 @@
 #include <Qt3DRender/QBuffer>
 #include <Qt3DCore/QTransform>
 
-namespace sfmdataentity
-{
+namespace sfmdataentity {
 
 PointCloudEntity::PointCloudEntity(Qt3DCore::QNode* parent)
-    : Qt3DCore::QEntity(parent)
-{
-}
+  : Qt3DCore::QEntity(parent)
+{}
 
-void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks & landmarks)
+void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks& landmarks)
 {
     using namespace Qt3DRender;
 
@@ -23,11 +21,11 @@ void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks & landmarks
 
     std::vector<float> points;
     std::vector<float> colors;
-    for (const auto & l : landmarks)
+    for (const auto& l : landmarks)
     {
         points.push_back(static_cast<float>(l.second.X(0)));
-        points.push_back(static_cast<float>(- l.second.X(1)));
-        points.push_back(static_cast<float>(- l.second.X(2)));
+        points.push_back(static_cast<float>(-l.second.X(1)));
+        points.push_back(static_cast<float>(-l.second.X(2)));
 
         colors.push_back(static_cast<float>(l.second.rgb(0) / 255.0f));
         colors.push_back(static_cast<float>(l.second.rgb(1) / 255.0f));

--- a/src/qmlSfmData/PointCloudEntity.hpp
+++ b/src/qmlSfmData/PointCloudEntity.hpp
@@ -3,18 +3,16 @@
 #include <QEntity>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 
-
-namespace sfmdataentity
-{
+namespace sfmdataentity {
 
 class PointCloudEntity : public Qt3DCore::QEntity
 {
     Q_OBJECT
 
-public:
+  public:
     explicit PointCloudEntity(Qt3DCore::QNode* = nullptr);
     ~PointCloudEntity() override = default;
-    void setData(const aliceVision::sfmData::Landmarks & landmarks);
+    void setData(const aliceVision::sfmData::Landmarks& landmarks);
 };
 
 }  // namespace sfmdataentity

--- a/src/qmlSfmData/SfmDataEntity.cpp
+++ b/src/qmlSfmData/SfmDataEntity.cpp
@@ -16,14 +16,12 @@
 #include <Qt3DExtras/QPerVertexColorMaterial>
 #include <QFile>
 
-
-namespace sfmdataentity
-{
+namespace sfmdataentity {
 
 SfmDataEntity::SfmDataEntity(Qt3DCore::QNode* parent)
-    : Qt3DCore::QEntity(parent),
-      _pointSizeParameter(new Qt3DRender::QParameter),
-      _ioThread(new IOThread())
+  : Qt3DCore::QEntity(parent),
+    _pointSizeParameter(new Qt3DRender::QParameter),
+    _ioThread(new IOThread())
 {
     connect(_ioThread.get(), &IOThread::finished, this, &SfmDataEntity::onIOThreadFinished);
     createMaterials();
@@ -179,7 +177,7 @@ void SfmDataEntity::onIOThreadFinished()
     }
     else
     {
-        Qt3DCore::QEntity * root = new Qt3DCore::QEntity(this);
+        Qt3DCore::QEntity* root = new Qt3DCore::QEntity(this);
 
         {
             PointCloudEntity* entity = new PointCloudEntity(root);
@@ -187,7 +185,7 @@ void SfmDataEntity::onIOThreadFinished()
             entity->addComponent(_cloudMaterial);
         }
 
-        for (const auto & pv : sfmData.getViews())
+        for (const auto& pv : sfmData.getViews())
         {
             if (!sfmData.isPoseAndIntrinsicDefined(pv.second.get()))
             {

--- a/src/qmlSfmData/SfmDataEntity.hpp
+++ b/src/qmlSfmData/SfmDataEntity.hpp
@@ -10,8 +10,7 @@
 
 #include <iostream>
 
-namespace sfmdataentity
-{
+namespace sfmdataentity {
 class PointCloudEntity;
 class CameraLocatorEntity;
 class IOThread;
@@ -28,13 +27,14 @@ class SfmDataEntity : public Qt3DCore::QEntity
 
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
 
-public:
+  public:
     // Identical to SceneLoader.Status
-    enum Status {
-            None = 0,
-            Loading,
-            Ready,
-            Error
+    enum Status
+    {
+        None = 0,
+        Loading,
+        Ready,
+        Error
     };
     Q_ENUM(Status)
 
@@ -50,7 +50,8 @@ public:
 
     Status status() const { return _status; }
 
-    void setStatus(Status status) {
+    void setStatus(Status status)
+    {
         if (status == _status)
             return;
         _status = status;
@@ -66,27 +67,21 @@ public:
     Q_SIGNAL void statusChanged(Status status);
     Q_SIGNAL void skipHiddenChanged();
 
-protected:
+  protected:
     /// Scale child locators
     void scaleLocators() const;
 
     void onIOThreadFinished();
 
-private:
+  private:
     /// Delete all child entities/components
     void clear();
     void loadSfmData();
     void createMaterials();
 
-    QQmlListProperty<CameraLocatorEntity> cameras()
-    {
-        return {this, &_cameras};
-    }
+    QQmlListProperty<CameraLocatorEntity> cameras() { return {this, &_cameras}; }
 
-    QQmlListProperty<PointCloudEntity> pointClouds()
-    {
-        return {this, &_pointClouds};
-    }
+    QQmlListProperty<PointCloudEntity> pointClouds() { return {this, &_pointClouds}; }
 
     Status _status = SfmDataEntity::None;
     QUrl _source;

--- a/src/qmlSfmData/plugin.hpp
+++ b/src/qmlSfmData/plugin.hpp
@@ -3,25 +3,22 @@
 #include <QtQml>
 #include <QQmlExtensionPlugin>
 
-namespace sfmdataentity
-{
+namespace sfmdataentity {
 
 class sfmDataEntityQmlPlugin : public QQmlExtensionPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "sfmDataEntity.qmlPlugin")
 
-public:
+  public:
     void initializeEngine(QQmlEngine*, const char*) override {}
     void registerTypes(const char* uri) override
     {
         Q_ASSERT(uri == QLatin1String("SfmDataEntity"));
 
         qmlRegisterType<SfmDataEntity>(uri, 1, 0, "SfmDataEntity");
-        qmlRegisterUncreatableType<CameraLocatorEntity>(uri, 1, 0, "CameraLocatorEntity",
-                                                        "Cannot create CameraLocatorEntity instances from QML.");
-        qmlRegisterUncreatableType<PointCloudEntity>(uri, 1, 0, "PointCloudEntity",
-                                                     "Cannot create PointCloudEntity instances from QML.");
+        qmlRegisterUncreatableType<CameraLocatorEntity>(uri, 1, 0, "CameraLocatorEntity", "Cannot create CameraLocatorEntity instances from QML.");
+        qmlRegisterUncreatableType<PointCloudEntity>(uri, 1, 0, "PointCloudEntity", "Cannot create PointCloudEntity instances from QML.");
     }
 };
 

--- a/src/qtAliceVision/FeaturesViewer.cpp
+++ b/src/qtAliceVision/FeaturesViewer.cpp
@@ -10,11 +10,10 @@
 #include <algorithm>
 #include <limits>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 FeaturesViewer::FeaturesViewer(QQuickItem* parent)
-    : QQuickItem(parent)
+  : QQuickItem(parent)
 {
     setFlag(QQuickItem::ItemHasContents, true);
 
@@ -51,9 +50,7 @@ FeaturesViewer::FeaturesViewer(QQuickItem* parent)
     connect(this, &FeaturesViewer::reconstructionChanged, this, &FeaturesViewer::update);
 }
 
-FeaturesViewer::~FeaturesViewer()
-{
-}
+FeaturesViewer::~FeaturesViewer() {}
 
 void FeaturesViewer::setMFeatures(MFeatures* features)
 {
@@ -237,8 +234,7 @@ void FeaturesViewer::paintFeaturesAsOrientedSquares(const PaintParams& params, Q
         // compute angle: use feature angle and remove self rotation
         const auto radAngle = -feature.orientation - qDegreesToRadians(rotation());
         // generate a QTransform that represent this rotation
-        const auto t =
-            QTransform().translate(feature.x, feature.y).rotateRadians(radAngle).translate(-feature.x, -feature.y);
+        const auto t = QTransform().translate(feature.x, feature.y).rotateRadians(radAngle).translate(-feature.x, -feature.y);
 
         // create lines, each vertice has to be duplicated (A->B, B->C, C->D, D->A) since we use GL_LINES
         std::vector<QPointF> corners = {t.map(tl), t.map(tr), t.map(br), t.map(bl)};
@@ -248,7 +244,7 @@ void FeaturesViewer::paintFeaturesAsOrientedSquares(const PaintParams& params, Q
             points.emplace_back(corners[(k + 1) % corners.size()]);
         }
         // orientation line: up vector (0, 1)
-        auto o2 = t.map(rect.center() - QPointF(0.0f, radius)); // rotate end point
+        auto o2 = t.map(rect.center() - QPointF(0.0f, radius));  // rotate end point
         points.emplace_back(rect.center());
         points.emplace_back(o2);
     }
@@ -260,7 +256,7 @@ void FeaturesViewer::updatePaintTracks(const PaintParams& params, QSGNode* node)
 {
     qDebug() << "[QtAliceVision] FeaturesViewer: Update paint " << _describerType << " tracks.";
 
-    if  (!_displayTracks || !params.haveValidFeatures || !params.haveValidTracks || !params.haveValidLandmarks)
+    if (!_displayTracks || !params.haveValidFeatures || !params.haveValidTracks || !params.haveValidLandmarks)
     {
         painter.clearLayer(node, "trackEndpoints");
         painter.clearLayer(node, "highlightPoints");
@@ -281,13 +277,14 @@ void FeaturesViewer::updatePaintTracks(const PaintParams& params, QSGNode* node)
     }
     catch (std::exception& e)
     {
-        qWarning() << "[QtAliceVision] FeaturesViewer: Failed to retrieve the current frame id." << "\n" << e.what();
+        qWarning() << "[QtAliceVision] FeaturesViewer: Failed to retrieve the current frame id."
+                   << "\n"
+                   << e.what();
     }
 
     if (currentFrameId == aliceVision::UndefinedIndexT)
     {
-        qInfo() << "[QtAliceVision] FeaturesViewer: Unable to update paint " << _describerType
-                << " tracks, can't find current frame id.";
+        qInfo() << "[QtAliceVision] FeaturesViewer: Unable to update paint " << _describerType << " tracks, can't find current frame id.";
         return;
     }
 
@@ -337,13 +334,13 @@ void FeaturesViewer::updatePaintTracks(const PaintParams& params, QSGNode* node)
         MReconstruction::FeatureData previousFeature;
         aliceVision::IndexT previousFrameId = aliceVision::UndefinedIndexT;
         bool previousFeatureInlier = false;
-        
+
         for (const auto& elt : track.elements)
         {
             // check that frameId is in timeWindow if enabled
-            if (_enableTimeWindow && (_timeWindow >= 0)
-                && (elt.frameId < currentFrameId - static_cast<aliceVision::IndexT>(_timeWindow) ||
-                    elt.frameId > currentFrameId + static_cast<aliceVision::IndexT>(_timeWindow)))
+            if (_enableTimeWindow && (_timeWindow >= 0) &&
+                (elt.frameId < currentFrameId - static_cast<aliceVision::IndexT>(_timeWindow) ||
+                 elt.frameId > currentFrameId + static_cast<aliceVision::IndexT>(_timeWindow)))
             {
                 continue;
             }
@@ -363,10 +360,10 @@ void FeaturesViewer::updatePaintTracks(const PaintParams& params, QSGNode* node)
                 const bool inliers = previousFeatureInlier && currentFeatureInlier;
 
                 // geometry
-                const QPointF prevPoint = (_display3dTracks && previousFeatureInlier)
-                    ? QPointF(previousFeature.rx, previousFeature.ry) : QPointF(previousFeature.x, previousFeature.y);
-                const QPointF curPoint = (_display3dTracks && currentFeatureInlier)
-                    ? QPointF(currentFeature.rx, currentFeature.ry) : QPointF(currentFeature.x, currentFeature.y);
+                const QPointF prevPoint = (_display3dTracks && previousFeatureInlier) ? QPointF(previousFeature.rx, previousFeature.ry)
+                                                                                      : QPointF(previousFeature.x, previousFeature.y);
+                const QPointF curPoint = (_display3dTracks && currentFeatureInlier) ? QPointF(currentFeature.rx, currentFeature.ry)
+                                                                                    : QPointF(currentFeature.x, currentFeature.y);
 
                 // track line
                 if (!contiguous)
@@ -413,8 +410,7 @@ void FeaturesViewer::updatePaintTracks(const PaintParams& params, QSGNode* node)
 
                 // track points
                 // current point
-                if (_trackDisplayMode == WithAllMatches ||
-                    (elt.frameId == currentFrameId && _trackDisplayMode == WithCurrentMatches))
+                if (_trackDisplayMode == WithAllMatches || (elt.frameId == currentFrameId && _trackDisplayMode == WithCurrentMatches))
                 {
                     if (currentFeatureInlier)
                     {
@@ -441,7 +437,6 @@ void FeaturesViewer::updatePaintTracks(const PaintParams& params, QSGNode* node)
 
                 if (_displayTrackEndpoints)
                 {
-
                     // draw global start point
                     if (previousFrameId == startFrameId)
                     {
@@ -474,13 +469,10 @@ void FeaturesViewer::updatePaintTracks(const PaintParams& params, QSGNode* node)
     painter.drawTriangles(node, "trackEndpoints", trackEndpoints, _endpointColor);
     painter.drawPoints(node, "highlightPoints", highlightPoints, QColor(255, 255, 255), 6.f);
     painter.drawLines(node, "trackLines_reconstruction_none", trackLines_reconstruction_none, _featureColor, 2.f);
-    painter.drawLines(node, "trackLines_reconstruction_partial_outliers", trackLines_reconstruction_partial_outliers,
-                      _matchColor, 2.f);
-    painter.drawLines(node, "trackLines_reconstruction_partial_inliers", trackLines_reconstruction_partial_inliers,
-                      _landmarkColor, 2.f);
+    painter.drawLines(node, "trackLines_reconstruction_partial_outliers", trackLines_reconstruction_partial_outliers, _matchColor, 2.f);
+    painter.drawLines(node, "trackLines_reconstruction_partial_inliers", trackLines_reconstruction_partial_inliers, _landmarkColor, 2.f);
     painter.drawLines(node, "trackLines_reconstruction_full", trackLines_reconstruction_full, _landmarkColor, 5.f);
-    painter.drawLines(node, "trackLines_gaps", trackLines_gaps,
-                      _trackContiguousFilter ? QColor(0, 0, 0, 0) : QColor(50, 50, 50), 2.f);
+    painter.drawLines(node, "trackLines_gaps", trackLines_gaps, _trackContiguousFilter ? QColor(0, 0, 0, 0) : QColor(50, 50, 50), 2.f);
     painter.drawPoints(node, "trackPoints_outliers", trackPoints_outliers, _matchColor, 4.f);
     painter.drawPoints(node, "trackPoints_inliers", trackPoints_inliers, _landmarkColor, 4.f);
 }
@@ -533,7 +525,7 @@ void FeaturesViewer::updatePaintLandmarks(const PaintParams& params, QSGNode* no
 {
     qDebug() << "[QtAliceVision] FeaturesViewer: Update paint " << _describerType << " landmarks.";
 
-    if  (!_displayLandmarks || !params.haveValidFeatures || !params.haveValidTracks || !params.haveValidLandmarks)
+    if (!_displayLandmarks || !params.haveValidFeatures || !params.haveValidTracks || !params.haveValidLandmarks)
     {
         // nothing to draw or something is not ready
         painter.clearLayer(node, "reprojectionErrors");
@@ -577,17 +569,14 @@ void FeaturesViewer::updatePaintLandmarks(const PaintParams& params, QSGNode* no
 
 void FeaturesViewer::initializePaintParams(PaintParams& params)
 {
-    params.haveValidFeatures = _mfeatures ?
-        _mfeatures->rawDataPtr() != nullptr && _mfeatures->status() == MFeatures::Ready : false;
+    params.haveValidFeatures = _mfeatures ? _mfeatures->rawDataPtr() != nullptr && _mfeatures->status() == MFeatures::Ready : false;
 
     if (!params.haveValidFeatures)
         return;
 
-    params.haveValidTracks = _mtracks ?
-        _mtracks->tracksPtr() != nullptr && _mtracks->status() == MTracks::Ready : false;
-    
-    params.haveValidLandmarks = _msfmdata ?
-        _msfmdata->rawDataPtr() != nullptr && _msfmdata->status() == MSfMData::Ready : false;
+    params.haveValidTracks = _mtracks ? _mtracks->tracksPtr() != nullptr && _mtracks->status() == MTracks::Ready : false;
+
+    params.haveValidLandmarks = _msfmdata ? _msfmdata->rawDataPtr() != nullptr && _msfmdata->status() == MSfMData::Ready : false;
 
     const float minFeatureScale = _mreconstruction.minFeatureScale;
     const float difFeatureScale = _mreconstruction.maxFeatureScale - minFeatureScale;
@@ -598,7 +587,7 @@ void FeaturesViewer::initializePaintParams(PaintParams& params)
 
 QSGNode* FeaturesViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdatePaintNodeData* data)
 {
-    (void)data; // Fix "unused parameter" warnings; should be replaced by [[maybe_unused]] when C++17 is supported
+    (void)data;  // Fix "unused parameter" warnings; should be replaced by [[maybe_unused]] when C++17 is supported
     PaintParams params;
     initializePaintParams(params);
 
@@ -631,15 +620,12 @@ void FeaturesViewer::updateReconstruction()
 
     // check validity of the different data sources
 
-    bool validFeatures = _mfeatures ?
-        _mfeatures->rawDataPtr() != nullptr && _mfeatures->status() == MFeatures::Ready : false;
-    
-    bool validTracks = _mtracks ?
-        _mtracks->tracksPtr() != nullptr && _mtracks->status() == MTracks::Ready : false;
-    
-    bool validLandmarks = _msfmdata ?
-        _msfmdata->rawDataPtr() != nullptr && _msfmdata->status() == MSfMData::Ready : false;
-    
+    bool validFeatures = _mfeatures ? _mfeatures->rawDataPtr() != nullptr && _mfeatures->status() == MFeatures::Ready : false;
+
+    bool validTracks = _mtracks ? _mtracks->tracksPtr() != nullptr && _mtracks->status() == MTracks::Ready : false;
+
+    bool validLandmarks = _msfmdata ? _msfmdata->rawDataPtr() != nullptr && _msfmdata->status() == MSfMData::Ready : false;
+
     // features
 
     if (validFeatures)
@@ -654,7 +640,7 @@ void FeaturesViewer::updateReconstruction()
 
         float minScale = std::numeric_limits<float>::max();
         float maxScale = 0.f;
-        
+
         for (const auto& [viewId, features] : featuresPerView)
         {
             std::vector<MReconstruction::FeatureData> featureDatas;
@@ -726,7 +712,7 @@ void FeaturesViewer::updateReconstruction()
     }
 
     // tracks
-    
+
     if (validTracks)
     {
         const auto& tracks = _mtracks->tracks();
@@ -745,8 +731,7 @@ void FeaturesViewer::updateReconstruction()
 
             for (const auto& [viewId, featureId] : track.featPerView)
             {
-                const auto featureDatasIt =
-                    _mreconstruction.featureDatasPerView.find(static_cast<aliceVision::IndexT>(viewId));
+                const auto featureDatasIt = _mreconstruction.featureDatasPerView.find(static_cast<aliceVision::IndexT>(viewId));
                 if (featureDatasIt == _mreconstruction.featureDatasPerView.end())
                 {
                     continue;
@@ -785,10 +770,8 @@ void FeaturesViewer::updateReconstruction()
 
             trackData.averageScale /= static_cast<float>(track.featPerView.size());
 
-            std::sort(trackData.elements.begin(), trackData.elements.end(),
-                [](const auto& elt1, const auto& elt2){
-                    return elt1.frameId < elt2.frameId;
-                });
+            std::sort(
+              trackData.elements.begin(), trackData.elements.end(), [](const auto& elt1, const auto& elt2) { return elt1.frameId < elt2.frameId; });
 
             _mreconstruction.trackDatas.push_back(trackData);
         }
@@ -799,4 +782,4 @@ void FeaturesViewer::updateReconstruction()
     Q_EMIT reconstructionChanged();
 }
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/FeaturesViewer.hpp
+++ b/src/qtAliceVision/FeaturesViewer.hpp
@@ -12,21 +12,20 @@
 #include <unordered_map>
 #include <string>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 /**
  * @brief Cached reconstruction data used for drawing by the FeaturesViewer.
- * 
+ *
  * Given a describer type, reconstruction data is organized in two parts:
  * - for each view, the features data with 3D reconstruction information if there is any
  * - the tracks, containing track elements ordered by frame number.
  */
 class MReconstruction
 {
-public:
-
-    struct FeatureData {
+  public:
+    struct FeatureData
+    {
         float x, y;
         float rx, ry;
         float scale;
@@ -35,13 +34,15 @@ public:
         bool hasLandmark;
     };
 
-    struct PointwiseTrackData {
+    struct PointwiseTrackData
+    {
         aliceVision::IndexT frameId = aliceVision::UndefinedIndexT;
         aliceVision::IndexT viewId = aliceVision::UndefinedIndexT;
         aliceVision::IndexT featureId = aliceVision::UndefinedIndexT;
     };
 
-    struct TrackData {
+    struct TrackData
+    {
         std::vector<PointwiseTrackData> elements;
         float averageScale;
         int nbReconstructed;
@@ -51,18 +52,17 @@ public:
     std::vector<TrackData> trackDatas;
     float minFeatureScale;
     float maxFeatureScale;
-
 };
 
 /**
  * @brief Display extracted features, matches, tracks and landmarks in 2D.
- * 
+ *
  * The FeaturesViewer uses MFeatures, MTracks and MSfMData to load data from disk
  * and keeps an MReconstruction instance to cache the reconstruction data
  * in a way that makes sense for drawing.
- * 
+ *
  * The various display options and filters can be manipulated from QML.
- * 
+ *
  * The FeaturesViewer relies on the Painter class for paiting routines and layer organization.
  */
 class FeaturesViewer : public QQuickItem
@@ -118,14 +118,14 @@ class FeaturesViewer : public QQuickItem
     // Pointer to SfmData
     Q_PROPERTY(qtAliceVision::MSfMData* msfmData READ getMSfMData WRITE setMSfMData NOTIFY sfmDataChanged)
 
-public:
+  public:
     /// Helpers
 
     enum FeatureDisplayMode
     {
-        Points = 0,     // Simple points (GL_POINTS)
-        Squares,        // Scaled filled squares (GL_TRIANGLES)
-        OrientedSquares // Scaled and oriented squares (GL_LINES)
+        Points = 0,      // Simple points (GL_POINTS)
+        Squares,         // Scaled filled squares (GL_TRIANGLES)
+        OrientedSquares  // Scaled and oriented squares (GL_LINES)
     };
     Q_ENUM(FeatureDisplayMode)
 
@@ -197,11 +197,11 @@ public:
     MSfMData* getMSfMData() { return _msfmdata; }
     void setMSfMData(MSfMData* sfmData);
 
-private:
+  private:
     /// Custom QSGNode update
     QSGNode* updatePaintNode(QSGNode* oldNode, QQuickItem::UpdatePaintNodeData* data) override;
 
-private:
+  private:
     void initializePaintParams(PaintParams& params);
     void updatePaintFeatures(const PaintParams& params, QSGNode* node);
     void paintFeaturesAsPoints(const PaintParams& params, QSGNode* node);
@@ -242,11 +242,19 @@ private:
     MSfMData* _msfmdata = nullptr;
     MReconstruction _mreconstruction;
 
-    Painter painter =
-        Painter({"features", "trackEndpoints", "highlightPoints", "trackLines_reconstruction_none",
-                 "trackLines_reconstruction_partial_outliers", "trackLines_reconstruction_partial_inliers",
-                 "trackLines_reconstruction_full", "trackLines_gaps", "trackPoints_outliers", "trackPoints_inliers",
-                 "matches", "reprojectionErrors", "landmarks"});
+    Painter painter = Painter({"features",
+                               "trackEndpoints",
+                               "highlightPoints",
+                               "trackLines_reconstruction_none",
+                               "trackLines_reconstruction_partial_outliers",
+                               "trackLines_reconstruction_partial_inliers",
+                               "trackLines_reconstruction_full",
+                               "trackLines_gaps",
+                               "trackPoints_outliers",
+                               "trackPoints_inliers",
+                               "matches",
+                               "reprojectionErrors",
+                               "landmarks"});
 };
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/FloatImageViewer.cpp
+++ b/src/qtAliceVision/FloatImageViewer.cpp
@@ -12,11 +12,10 @@
 #include <vector>
 #include <utility>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 FloatImageViewer::FloatImageViewer(QQuickItem* parent)
-    : QQuickItem(parent)
+  : QQuickItem(parent)
 {
     setFlag(QQuickItem::ItemHasContents, true);
 
@@ -49,8 +48,7 @@ FloatImageViewer::FloatImageViewer(QQuickItem* parent)
     connect(this, &FloatImageViewer::useSequenceChanged, this, &FloatImageViewer::reload);
 }
 
-FloatImageViewer::~FloatImageViewer()
-{}
+FloatImageViewer::~FloatImageViewer() {}
 
 // LOADING FUNCTIONS
 void FloatImageViewer::setLoading(bool loading)
@@ -75,10 +73,7 @@ void FloatImageViewer::setTargetSize(int size)
     Q_EMIT targetSizeChanged();
 }
 
-QVariantList FloatImageViewer::getCachedFrames() const
-{
-    return _sequenceCache.getCachedFrames();
-}
+QVariantList FloatImageViewer::getCachedFrames() const { return _sequenceCache.getCachedFrames(); }
 
 void FloatImageViewer::reload()
 {
@@ -90,7 +85,8 @@ void FloatImageViewer::reload()
     }
 
     _outdated = false;
-    if (_loading) _outdated = true;
+    if (_loading)
+        _outdated = true;
 
     if (!_source.isValid())
     {
@@ -159,7 +155,7 @@ QVector4D FloatImageViewer::pixelValueAt(int x, int y)
 
 QSGNode* FloatImageViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdatePaintNodeData* data)
 {
-    (void)data; // Fix "unused parameter" warnings; should be replaced by [[maybe_unused]] when C++17 is supported
+    (void)data;  // Fix "unused parameter" warnings; should be replaced by [[maybe_unused]] when C++17 is supported
     QVector4D channelOrder(0.f, 1.f, 2.f, 3.f);
 
     QSGGeometryNode* root = static_cast<QSGGeometryNode*>(oldNode);
@@ -170,8 +166,7 @@ QSGNode* FloatImageViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdateP
     if (!root)
     {
         root = new QSGGeometryNode;
-        auto geometry = new QSGGeometry(QSGGeometry::defaultAttributes_TexturedPoint2D(), _surface.vertexCount(),
-                                        _surface.indexCount());
+        auto geometry = new QSGGeometry(QSGGeometry::defaultAttributes_TexturedPoint2D(), _surface.vertexCount(), _surface.indexCount());
         geometry->setDrawingMode(GL_TRIANGLES);
         geometry->setIndexDataPattern(QSGGeometry::StaticPattern);
         geometry->setVertexDataPattern(QSGGeometry::StaticPattern);
@@ -273,9 +268,8 @@ QSGNode* FloatImageViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdateP
             const aliceVision::camera::Equidistant* intrinsicEquidistant = _surface.getIntrinsicEquidistant();
             if (_cropFisheye && intrinsicEquidistant)
             {
-                const aliceVision::Vec3 fisheyeCircleParams(intrinsicEquidistant->getCircleCenterX(),
-                                                            intrinsicEquidistant->getCircleCenterY(),
-                                                            intrinsicEquidistant->getCircleRadius());
+                const aliceVision::Vec3 fisheyeCircleParams(
+                  intrinsicEquidistant->getCircleCenterX(), intrinsicEquidistant->getCircleCenterY(), intrinsicEquidistant->getCircleRadius());
 
                 const double width = _image->Width() * pow(2.0, _downscaleLevel);
                 const double height = _image->Height() * pow(2.0, _downscaleLevel);
@@ -286,8 +280,8 @@ QSGNode* FloatImageViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdateP
                 // Radius is converted in uv coordinates (0, 0.5)
                 const float radius = 0.5f * static_cast<float>(radiusInPercentage);
 
-                material->state()->fisheyeCircleCoord = QVector2D(static_cast<float>(fisheyeCircleParams.x() / width),
-                                                                  static_cast<float>(fisheyeCircleParams.y() / height));
+                material->state()->fisheyeCircleCoord =
+                  QVector2D(static_cast<float>(fisheyeCircleParams.x() / width), static_cast<float>(fisheyeCircleParams.y() / height));
                 material->state()->fisheyeCircleRadius = radius;
                 material->state()->aspectRatio = static_cast<float>(aspectRatio);
             }
@@ -344,8 +338,7 @@ QSGNode* FloatImageViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdateP
     return root;
 }
 
-void FloatImageViewer::updatePaintSurface(QSGGeometryNode* root, QSGSimpleMaterial<ShaderData>* material,
-                                          QSGGeometry* geometryLine)
+void FloatImageViewer::updatePaintSurface(QSGGeometryNode* root, QSGSimpleMaterial<ShaderData>* material, QSGGeometry* geometryLine)
 {
     // Highlight
     if (_canBeHovered)
@@ -382,4 +375,4 @@ void FloatImageViewer::updatePaintSurface(QSGGeometryNode* root, QSGSimpleMateri
     root->childAtIndex(0)->markDirty(QSGNode::DirtyGeometry | QSGNode::DirtyMaterial);
 }
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/FloatImageViewer.hpp
+++ b/src/qtAliceVision/FloatImageViewer.hpp
@@ -20,15 +20,13 @@
 #include <string>
 #include <algorithm>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 /**
  * @brief Load and display image.
  */
 class FloatImageViewer : public QQuickItem
 {
-
     Q_OBJECT
     // Q_PROPERTIES
     Q_PROPERTY(QUrl source MEMBER _source NOTIFY sourceChanged)
@@ -65,8 +63,7 @@ class FloatImageViewer : public QQuickItem
 
     Q_PROPERTY(bool useSequence MEMBER _useSequence NOTIFY useSequenceChanged)
 
-
-public:
+  public:
     explicit FloatImageViewer(QQuickItem* parent = nullptr);
     ~FloatImageViewer() override;
 
@@ -137,7 +134,7 @@ public:
 
     QVariantList getCachedFrames() const;
 
-private:
+  private:
     /// Reload image from source
     void reload();
 
@@ -178,7 +175,7 @@ private:
     bool _useSequence = true;
 };
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision
 
 Q_DECLARE_METATYPE(qtAliceVision::FloatImage)
 Q_DECLARE_METATYPE(std::shared_ptr<qtAliceVision::FloatImage>)

--- a/src/qtAliceVision/FloatTexture.cpp
+++ b/src/qtAliceVision/FloatTexture.cpp
@@ -6,8 +6,7 @@
 
 #include <QtDebug>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 int FloatTexture::_maxTextureSize = -1;
 
 FloatTexture::FloatTexture() {}
@@ -29,10 +28,7 @@ void FloatTexture::setImage(std::shared_ptr<FloatImage>& image)
     _mipmapsGenerated = false;
 }
 
-bool FloatTexture::isValid() const
-{
-    return _srcImage->Width() != 0 && _srcImage->Height() != 0;
-}
+bool FloatTexture::isValid() const { return _srcImage->Width() != 0 && _srcImage->Height() != 0; }
 
 int FloatTexture::textureId() const
 {
@@ -44,8 +40,7 @@ int FloatTexture::textureId() const
         }
         else if (_textureId == 0)
         {
-            QOpenGLContext::currentContext()->functions()->glGenTextures(1,
-                                                                         &const_cast<FloatTexture*>(this)->_textureId);
+            QOpenGLContext::currentContext()->functions()->glGenTextures(1, &const_cast<FloatTexture*>(this)->_textureId);
             return static_cast<int>(_textureId);
         }
     }
@@ -107,8 +102,7 @@ void FloatTexture::bind()
 
         updateBindOptions(_dirtyBindOptions);
 
-        funcs->glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, _textureSize.width(), _textureSize.height(), 0, GL_RGBA,
-                            GL_FLOAT, _srcImage->data());
+        funcs->glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, _textureSize.width(), _textureSize.height(), 0, GL_RGBA, GL_FLOAT, _srcImage->data());
 
         if (mipmapFiltering() != QSGTexture::None)
         {
@@ -127,4 +121,4 @@ void FloatTexture::bind()
     }
 }
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/FloatTexture.hpp
+++ b/src/qtAliceVision/FloatTexture.hpp
@@ -8,8 +8,7 @@
 
 #include <memory>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 using FloatImage = aliceVision::image::Image<aliceVision::image::RGBAfColor>;
 
@@ -18,7 +17,7 @@ using FloatImage = aliceVision::image::Image<aliceVision::image::RGBAfColor>;
  */
 class FloatTexture : public QSGTexture
 {
-public:
+  public:
     FloatTexture();
     ~FloatTexture() override;
 
@@ -31,7 +30,7 @@ public:
     bool hasMipmaps() const override { return mipmapFiltering() != QSGTexture::None; }
 
     void setImage(std::shared_ptr<FloatImage>& image);
-    const FloatImage &image() { return *_srcImage; }
+    const FloatImage& image() { return *_srcImage; }
 
     void bind() override;
 
@@ -44,10 +43,10 @@ public:
      */
     static int maxTextureSize() { return _maxTextureSize; }
 
-private:
+  private:
     bool isValid() const;
 
-private:
+  private:
     std::shared_ptr<FloatImage> _srcImage;
 
     unsigned int _textureId = 0;
@@ -60,4 +59,4 @@ private:
     static int _maxTextureSize;
 };
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/ImageServer.hpp
+++ b/src/qtAliceVision/ImageServer.hpp
@@ -10,53 +10,48 @@
 #include <string>
 #include <memory>
 
-
 namespace qtAliceVision {
 namespace imgserve {
 
 /**
  * @brief Utility structure to encapsulate an image loading request.
  */
-struct RequestData {
-
+struct RequestData
+{
     std::string path;
 
     int downscale = 1;
-
 };
 
 /**
  * @brief Utility structure to encapsulate the response to an image loading request.
  */
-struct ResponseData {
+struct ResponseData
+{
+    std::shared_ptr<aliceVision::image::Image<aliceVision::image::RGBAfColor>> img;
 
-	std::shared_ptr<aliceVision::image::Image<aliceVision::image::RGBAfColor>> img;
+    QSize dim;
 
-	QSize dim;
-
-	QVariantMap metadata;
-
+    QVariantMap metadata;
 };
 
 /**
  * @brief Interface for loading images from disk.
  */
-class ImageServer {
-
-public:
-
-	/**
-	 * @brief Request an image stored on disk with its metadata.
-	 * @note this is a pure virtual method
-	 * @param[in] path image's filepath on disk
-	 * @return a response to the request containing a pointer to the image and the image's metadata
-	 */
-	virtual ResponseData request(const RequestData& reqData) = 0;
-
+class ImageServer
+{
+  public:
+    /**
+     * @brief Request an image stored on disk with its metadata.
+     * @note this is a pure virtual method
+     * @param[in] path image's filepath on disk
+     * @return a response to the request containing a pointer to the image and the image's metadata
+     */
+    virtual ResponseData request(const RequestData& reqData) = 0;
 };
 
-} // namespace imgserve
-} // namespace qtAliceVision
+}  // namespace imgserve
+}  // namespace qtAliceVision
 
 // Make RequestData and ResponseData struct known to QMetaType
 // for usage in signals and slots

--- a/src/qtAliceVision/MFeatures.cpp
+++ b/src/qtAliceVision/MFeatures.cpp
@@ -15,8 +15,7 @@
 #include <memory>
 #include <limits>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 void FeaturesIORunnable::run()
 {
@@ -25,14 +24,11 @@ void FeaturesIORunnable::run()
     std::vector<aliceVision::feature::EImageDescriberType> imageDescriberTypes;
     for (const auto& descType : _describerTypes)
     {
-        imageDescriberTypes.emplace_back(
-            aliceVision::feature::EImageDescriberType_stringToEnum(descType));
+        imageDescriberTypes.emplace_back(aliceVision::feature::EImageDescriberType_stringToEnum(descType));
     }
 
     std::vector<std::vector<std::unique_ptr<aliceVision::feature::Regions>>> regionsPerViewPerDesc;
-    bool loaded
-        = aliceVision::sfm::loadFeaturesPerDescPerView(
-            regionsPerViewPerDesc, _viewIds, _folders, imageDescriberTypes);
+    bool loaded = aliceVision::sfm::loadFeaturesPerDescPerView(regionsPerViewPerDesc, _viewIds, _folders, imageDescriberTypes);
 
     if (!loaded)
     {
@@ -46,15 +42,13 @@ void FeaturesIORunnable::run()
     {
         const auto& descTypeStr = _describerTypes.at(dIdx);
 
-        const std::vector<std::unique_ptr<aliceVision::feature::Regions>>& regionsPerView =
-            regionsPerViewPerDesc.at(static_cast<uint>(dIdx));
+        const std::vector<std::unique_ptr<aliceVision::feature::Regions>>& regionsPerView = regionsPerViewPerDesc.at(static_cast<uint>(dIdx));
 
         for (std::size_t vIdx = 0; vIdx < _viewIds.size(); ++vIdx)
         {
             const auto& viewId = _viewIds.at(vIdx);
 
-            qDebug() << "[QtAliceVision] Features: Load " << descTypeStr
-                     << " from viewId: " << viewId << ".";
+            qDebug() << "[QtAliceVision] Features: Load " << descTypeStr << " from viewId: " << viewId << ".";
 
             (*featuresPerViewPerDesc)[descTypeStr][viewId] = regionsPerView.at(vIdx)->Features();
         }
@@ -73,7 +67,8 @@ MFeatures::MFeatures()
 
 MFeatures::~MFeatures()
 {
-    if (_featuresPerViewPerDesc) delete _featuresPerViewPerDesc;
+    if (_featuresPerViewPerDesc)
+        delete _featuresPerViewPerDesc;
 
     setStatus(None);
 }
@@ -133,9 +128,8 @@ void MFeatures::load()
         describerTypes.push_back(var.toString().toStdString());
     }
 
-    FeaturesIORunnable* ioRunnable =
-        new FeaturesIORunnable(folders, viewIds, describerTypes);
-    
+    FeaturesIORunnable* ioRunnable = new FeaturesIORunnable(folders, viewIds, describerTypes);
+
     connect(ioRunnable, &FeaturesIORunnable::resultReady, this, &MFeatures::onFeaturesReady);
 
     QThreadPool::globalInstance()->start(ioRunnable);
@@ -145,7 +139,8 @@ void MFeatures::onFeaturesReady(FeaturesPerViewPerDesc* featuresPerViewPerDesc)
 {
     if (_needReload)
     {
-        if (featuresPerViewPerDesc) delete featuresPerViewPerDesc;
+        if (featuresPerViewPerDesc)
+            delete featuresPerViewPerDesc;
 
         setStatus(None);
         load();
@@ -154,7 +149,8 @@ void MFeatures::onFeaturesReady(FeaturesPerViewPerDesc* featuresPerViewPerDesc)
 
     if (featuresPerViewPerDesc)
     {
-        if (_featuresPerViewPerDesc) delete _featuresPerViewPerDesc;
+        if (_featuresPerViewPerDesc)
+            delete _featuresPerViewPerDesc;
 
         _featuresPerViewPerDesc = featuresPerViewPerDesc;
     }
@@ -210,6 +206,6 @@ int MFeatures::nbFeatures(QString describerType, int viewId) const
     return static_cast<int>(features.size());
 }
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision
 
 #include "MFeatures.moc"

--- a/src/qtAliceVision/MFeatures.hpp
+++ b/src/qtAliceVision/MFeatures.hpp
@@ -12,23 +12,21 @@
 #include <vector>
 #include <string>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
-using FeaturesPerViewPerDesc =
-    std::map<std::string, std::map<aliceVision::IndexT, std::vector<aliceVision::feature::PointFeature>>>;
+using FeaturesPerViewPerDesc = std::map<std::string, std::map<aliceVision::IndexT, std::vector<aliceVision::feature::PointFeature>>>;
 
 /**
  * @brief QObject wrapper around extracted features.
- * 
+ *
  * Given a folder containing extracted features,
  * the role of an MFeatures instance is to load the features from disk.
  * Describer types and view IDs to load must also be specified.
  * This task is done asynchronously to avoid freezing the UI.
- * 
+ *
  * MFeatures objects are accessible from QML
  * and can be manipulated through their properties.
- * 
+ *
  * Note:
  * for a given describer type and view ID,
  * features are stored in an array-like structure
@@ -51,7 +49,7 @@ class MFeatures : public QObject
 
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
 
-public:
+  public:
     /// Status Enum
 
     enum Status
@@ -93,7 +91,7 @@ public:
     Status status() const { return _status; }
     void setStatus(Status status);
 
-private:
+  private:
     /// Private members
 
     QVariantList _featureFolders;
@@ -113,13 +111,14 @@ class FeaturesIORunnable : public QObject, public QRunnable
 {
     Q_OBJECT
 
-public:
+  public:
     FeaturesIORunnable(const std::vector<std::string>& folders,
                        const std::vector<aliceVision::IndexT>& viewIds,
                        const std::vector<std::string>& describerTypes)
-        : _folders(folders), _viewIds(viewIds), _describerTypes(describerTypes)
-    {
-    }
+      : _folders(folders),
+        _viewIds(viewIds),
+        _describerTypes(describerTypes)
+    {}
 
     /// Load features based on input parameters
     Q_SLOT void run() override;
@@ -132,10 +131,10 @@ public:
      */
     Q_SIGNAL void resultReady(FeaturesPerViewPerDesc* featuresPerViewPerDesc);
 
-private:
+  private:
     std::vector<std::string> _folders;
     std::vector<aliceVision::IndexT> _viewIds;
     std::vector<std::string> _describerTypes;
 };
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/MSfMData.cpp
+++ b/src/qtAliceVision/MSfMData.cpp
@@ -6,8 +6,7 @@
 
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 void SfmDataIORunnable::run()
 {
@@ -30,14 +29,12 @@ void SfmDataIORunnable::run()
     Q_EMIT resultReady(sfmData);
 }
 
-MSfMData::MSfMData()
-{
-    connect(this, &MSfMData::sfmDataPathChanged, this, &MSfMData::load);
-}
+MSfMData::MSfMData() { connect(this, &MSfMData::sfmDataPathChanged, this, &MSfMData::load); }
 
 MSfMData::~MSfMData()
 {
-    if (_sfmData) delete _sfmData;
+    if (_sfmData)
+        delete _sfmData;
 
     setStatus(None);
 }
@@ -81,7 +78,8 @@ void MSfMData::onSfmDataReady(aliceVision::sfmData::SfMData* sfmData)
 {
     if (_needReload)
     {
-        if (sfmData) delete sfmData;
+        if (sfmData)
+            delete sfmData;
 
         setStatus(None);
         load();
@@ -90,7 +88,8 @@ void MSfMData::onSfmDataReady(aliceVision::sfmData::SfMData* sfmData)
 
     if (sfmData)
     {
-        if (_sfmData) delete _sfmData;
+        if (_sfmData)
+            delete _sfmData;
 
         _sfmData = sfmData;
     }
@@ -145,10 +144,12 @@ int MSfMData::nbLandmarks(QString describerType, int viewId) const
     auto descType = aliceVision::feature::EImageDescriberType_stringToEnum(describerType.toStdString());
     for (const auto& [_, landmark] : landmarks)
     {
-        if (landmark.descType != descType) continue;
+        if (landmark.descType != descType)
+            continue;
 
         const auto observationIt = landmark.observations.find(viewId);
-        if (observationIt == landmark.observations.end()) continue;
+        if (observationIt == landmark.observations.end())
+            continue;
 
         ++count;
     }
@@ -156,6 +157,6 @@ int MSfMData::nbLandmarks(QString describerType, int viewId) const
     return count;
 }
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision
 
 #include "MSfMData.moc"

--- a/src/qtAliceVision/MSfMData.hpp
+++ b/src/qtAliceVision/MSfMData.hpp
@@ -9,19 +9,18 @@
 #include <memory>
 #include <string>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 /**
  * @brief QObject wrapper around a SfMData.
- * 
+ *
  * Given a path to a SfMData file,
  * the role of an MSfMData instance is to load the SfMData from disk.
  * This task is done asynchronously to avoid freezing the UI.
- * 
+ *
  * MSfMData objects are accesible from QML
  * and can be manipulated through their properties.
- * 
+ *
  * Note:
  * a SfMData contains important information for linking together various reconstruction data, such as:
  * - views (and their corresponding frame ID)
@@ -46,7 +45,7 @@ class MSfMData : public QObject
 
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
 
-public:
+  public:
     /// Status enum
 
     enum Status
@@ -62,10 +61,10 @@ public:
     MSfMData& operator=(const MSfMData& other) = default;
     ~MSfMData() override;
 
-private:
+  private:
     MSfMData(const MSfMData& other);
 
-public:
+  public:
     /// Slots
 
     Q_SLOT void load();
@@ -83,7 +82,7 @@ public:
     Q_INVOKABLE QString getUrlFromViewId(int viewId);
     Q_INVOKABLE int nbLandmarks(QString describerType, int viewId) const;
 
-public:
+  public:
     const aliceVision::sfmData::SfMData& rawData() const { return *_sfmData; }
     aliceVision::sfmData::SfMData& rawData() { return *_sfmData; }
     const aliceVision::sfmData::SfMData* rawDataPtr() const { return _sfmData; }
@@ -95,7 +94,7 @@ public:
 
     QVariantList getViewsIds() const;
 
-private:
+  private:
     /// Private members
 
     QUrl _sfmDataPath;
@@ -112,11 +111,10 @@ private:
 class SfmDataIORunnable : public QObject, public QRunnable
 {
     Q_OBJECT
-public:
+  public:
     explicit SfmDataIORunnable(const QUrl& sfmDataPath)
-        : _sfmDataPath(sfmDataPath)
-    {
-    }
+      : _sfmDataPath(sfmDataPath)
+    {}
 
     /// Load SfM based on input parameters
     Q_SLOT void run() override;
@@ -126,8 +124,8 @@ public:
      */
     Q_SIGNAL void resultReady(aliceVision::sfmData::SfMData* sfmData);
 
-private:
+  private:
     const QUrl _sfmDataPath;
 };
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/MSfMDataStats.cpp
+++ b/src/qtAliceVision/MSfMDataStats.cpp
@@ -4,8 +4,7 @@
 
 #include <ctime>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 void MSfMDataStats::fillLandmarksPerViewSerie(QXYSeries* landmarksPerView)
 {
@@ -185,8 +184,7 @@ void MSfMDataStats::fillObservationsLengthsMinPerViewSerie(QXYSeries* observatio
 {
     if (observationsLengthsPerView == nullptr)
     {
-        qInfo()
-            << "[QtAliceVision] MSfMDataStats::fillObservationsLengthsMinPerViewSerie: no observationsLengthsPerView";
+        qInfo() << "[QtAliceVision] MSfMDataStats::fillObservationsLengthsMinPerViewSerie: no observationsLengthsPerView";
         return;
     }
     observationsLengthsPerView->clear();
@@ -207,8 +205,7 @@ void MSfMDataStats::fillObservationsLengthsMaxPerViewSerie(QXYSeries* observatio
 {
     if (observationsLengthsPerView == nullptr)
     {
-        qInfo()
-            << "[QtAliceVision] MSfMDataStats::fillObservationsLengthsMaxPerViewSerie: no observationsLengthsPerView";
+        qInfo() << "[QtAliceVision] MSfMDataStats::fillObservationsLengthsMaxPerViewSerie: no observationsLengthsPerView";
         return;
     }
     observationsLengthsPerView->clear();
@@ -229,8 +226,7 @@ void MSfMDataStats::fillObservationsLengthsMeanPerViewSerie(QXYSeries* observati
 {
     if (observationsLengthsPerView == nullptr)
     {
-        qInfo()
-            << "[QtAliceVision] MSfMDataStats::fillObservationsLengthsMeanPerViewSerie: no observationsLengthsPerView";
+        qInfo() << "[QtAliceVision] MSfMDataStats::fillObservationsLengthsMeanPerViewSerie: no observationsLengthsPerView";
         return;
     }
     observationsLengthsPerView->clear();
@@ -368,9 +364,14 @@ void MSfMDataStats::computeGlobalSfMStats()
     // Residuals Per View graph
     {
         _residualsPerViewMaxAxisX = 0;
-        sfm::computeResidualsPerView(_msfmData->rawData(), _residualsPerViewMaxAxisX, _nbResidualsPerViewMin,
-                                     _nbResidualsPerViewMax, _nbResidualsPerViewMean, _nbResidualsPerViewMedian,
-                                     _nbResidualsPerViewFirstQuartile, _nbResidualsPerViewThirdQuartile);
+        sfm::computeResidualsPerView(_msfmData->rawData(),
+                                     _residualsPerViewMaxAxisX,
+                                     _nbResidualsPerViewMin,
+                                     _nbResidualsPerViewMax,
+                                     _nbResidualsPerViewMean,
+                                     _nbResidualsPerViewMedian,
+                                     _nbResidualsPerViewFirstQuartile,
+                                     _nbResidualsPerViewThirdQuartile);
         _residualsPerViewMaxAxisY = 0.0;
 
         for (std::size_t i = 0; i < _nbResidualsPerViewMin.size(); ++i)
@@ -378,12 +379,9 @@ void MSfMDataStats::computeGlobalSfMStats()
             _residualsPerViewMaxAxisY = round(std::max(_residualsPerViewMaxAxisY, double(_nbResidualsPerViewMin[i])));
             _residualsPerViewMaxAxisY = round(std::max(_residualsPerViewMaxAxisY, double(_nbResidualsPerViewMax[i])));
             _residualsPerViewMaxAxisY = round(std::max(_residualsPerViewMaxAxisY, double(_nbResidualsPerViewMean[i])));
-            _residualsPerViewMaxAxisY =
-                round(std::max(_residualsPerViewMaxAxisY, double(_nbResidualsPerViewMedian[i])));
-            _residualsPerViewMaxAxisY =
-                round(std::max(_residualsPerViewMaxAxisY, double(_nbResidualsPerViewFirstQuartile[i])));
-            _residualsPerViewMaxAxisY =
-                round(std::max(_residualsPerViewMaxAxisY, double(_nbResidualsPerViewThirdQuartile[i])));
+            _residualsPerViewMaxAxisY = round(std::max(_residualsPerViewMaxAxisY, double(_nbResidualsPerViewMedian[i])));
+            _residualsPerViewMaxAxisY = round(std::max(_residualsPerViewMaxAxisY, double(_nbResidualsPerViewFirstQuartile[i])));
+            _residualsPerViewMaxAxisY = round(std::max(_residualsPerViewMaxAxisY, double(_nbResidualsPerViewThirdQuartile[i])));
         }
     }
 
@@ -392,26 +390,27 @@ void MSfMDataStats::computeGlobalSfMStats()
     // Observations Lengths Per View graph
     {
         _observationsLengthsPerViewMaxAxisX = 0;
-        sfm::computeObservationsLengthsPerView(
-            _msfmData->rawData(), _observationsLengthsPerViewMaxAxisX, _nbObservationsLengthsPerViewMin,
-            _nbObservationsLengthsPerViewMax, _nbObservationsLengthsPerViewMean, _nbObservationsLengthsPerViewMedian,
-            _nbObservationsLengthsPerViewFirstQuartile, _nbObservationsLengthsPerViewThirdQuartile);
+        sfm::computeObservationsLengthsPerView(_msfmData->rawData(),
+                                               _observationsLengthsPerViewMaxAxisX,
+                                               _nbObservationsLengthsPerViewMin,
+                                               _nbObservationsLengthsPerViewMax,
+                                               _nbObservationsLengthsPerViewMean,
+                                               _nbObservationsLengthsPerViewMedian,
+                                               _nbObservationsLengthsPerViewFirstQuartile,
+                                               _nbObservationsLengthsPerViewThirdQuartile);
         _observationsLengthsPerViewMaxAxisY = 0.0;
 
         for (std::size_t i = 0; i < _nbObservationsLengthsPerViewMin.size(); ++i)
         {
+            _observationsLengthsPerViewMaxAxisY = round(std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewMin[i])));
+            _observationsLengthsPerViewMaxAxisY = round(std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewMax[i])));
+            _observationsLengthsPerViewMaxAxisY = round(std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewMean[i])));
             _observationsLengthsPerViewMaxAxisY =
-                round(std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewMin[i])));
+              round(std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewMedian[i])));
             _observationsLengthsPerViewMaxAxisY =
-                round(std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewMax[i])));
+              round(std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewFirstQuartile[i])));
             _observationsLengthsPerViewMaxAxisY =
-                round(std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewMean[i])));
-            _observationsLengthsPerViewMaxAxisY =
-                round(std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewMedian[i])));
-            _observationsLengthsPerViewMaxAxisY = round(
-                std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewFirstQuartile[i])));
-            _observationsLengthsPerViewMaxAxisY = round(
-                std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewThirdQuartile[i])));
+              round(std::max(_observationsLengthsPerViewMaxAxisY, double(_nbObservationsLengthsPerViewThirdQuartile[i])));
         }
     }
 
@@ -431,8 +430,7 @@ void MSfMDataStats::computeGlobalTracksStats()
     }
     if (_mTracks->status() != MTracks::Ready)
     {
-        qInfo() << "[QtAliceVision] MSfMDataStats::computeGlobalTracksStats: Tracks is not ready: "
-                << _mTracks->status();
+        qInfo() << "[QtAliceVision] MSfMDataStats::computeGlobalTracksStats: Tracks is not ready: " << _mTracks->status();
         return;
     }
     if (_mTracks->tracks().empty())
@@ -447,8 +445,7 @@ void MSfMDataStats::computeGlobalTracksStats()
     }
     if (_msfmData->status() != MSfMData::Ready)
     {
-        qInfo() << "[QtAliceVision] MSfMDataStats::computeGlobalTracksStats: SfMData is not ready: "
-                << _msfmData->status();
+        qInfo() << "[QtAliceVision] MSfMDataStats::computeGlobalTracksStats: SfMData is not ready: " << _msfmData->status();
         return;
     }
 
@@ -522,4 +519,4 @@ void MSfMDataStats::setMTracks(qtAliceVision::MTracks* tracks)
     Q_EMIT tracksChanged();
 }
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/MSfMDataStats.hpp
+++ b/src/qtAliceVision/MSfMDataStats.hpp
@@ -13,8 +13,7 @@
 #include <MSfMData.hpp>
 #include <MTracks.hpp>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 QT_CHARTS_USE_NAMESPACE
 
@@ -39,7 +38,7 @@ class MSfMDataStats : public QObject
     /// max AxisY value for residuals per view histogram
     Q_PROPERTY(double observationsLengthsPerViewMaxAxisY MEMBER _observationsLengthsPerViewMaxAxisY NOTIFY axisChanged)
 
-public:
+  public:
     MSfMDataStats()
     {
         connect(this, &MSfMDataStats::sfmDataChanged, this, &MSfMDataStats::computeGlobalSfMStats);
@@ -81,7 +80,7 @@ public:
     MTracks* getMTracks() { return _mTracks; }
     void setMTracks(qtAliceVision::MTracks* tracks);
 
-private:
+  private:
     MSfMData* _msfmData = nullptr;
     MTracks* _mTracks = nullptr;
 
@@ -107,4 +106,4 @@ private:
     std::vector<double> _nbTracksPerView;
 };
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/MTracks.cpp
+++ b/src/qtAliceVision/MTracks.cpp
@@ -9,8 +9,7 @@
 #include <QThreadPool>
 #include <QString>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 void TracksIORunnable::run()
 {
@@ -43,15 +42,14 @@ void TracksIORunnable::run()
     Q_EMIT resultReady(tracks, tracksPerView);
 }
 
-MTracks::MTracks()
-{
-    connect(this, &MTracks::matchingFoldersChanged, this, &MTracks::load);
-}
+MTracks::MTracks() { connect(this, &MTracks::matchingFoldersChanged, this, &MTracks::load); }
 
 MTracks::~MTracks()
 {
-    if (_tracks) delete _tracks;
-    if (_tracksPerView) delete _tracksPerView;
+    if (_tracks)
+        delete _tracks;
+    if (_tracksPerView)
+        delete _tracksPerView;
 
     setStatus(None);
 }
@@ -93,8 +91,10 @@ void MTracks::onReady(aliceVision::track::TracksMap* tracks, aliceVision::track:
 {
     if (_needReload)
     {
-        if (tracks) delete tracks;
-        if (tracksPerView) delete tracksPerView;
+        if (tracks)
+            delete tracks;
+        if (tracksPerView)
+            delete tracksPerView;
 
         setStatus(None);
         load();
@@ -103,8 +103,10 @@ void MTracks::onReady(aliceVision::track::TracksMap* tracks, aliceVision::track:
 
     if (tracks && tracksPerView)
     {
-        if (_tracks) delete _tracks;
-        if (_tracksPerView) delete _tracksPerView;
+        if (_tracks)
+            delete _tracks;
+        if (_tracksPerView)
+            delete _tracksPerView;
 
         _tracks = tracks;
         _tracksPerView = tracksPerView;
@@ -117,7 +119,7 @@ void MTracks::onReady(aliceVision::track::TracksMap* tracks, aliceVision::track:
     {
         delete tracksPerView;
     }
-    
+
     setStatus(Ready);
 }
 
@@ -158,7 +160,8 @@ int MTracks::nbMatches(QString describerType, int viewId) const
     for (const auto& trackId : trackIds)
     {
         const auto trackIt = _tracks->find(trackId);
-        if (trackIt == _tracks->end()) continue;
+        if (trackIt == _tracks->end())
+            continue;
 
         const auto& track = trackIt->second;
         if (track.descType == descType)
@@ -170,6 +173,6 @@ int MTracks::nbMatches(QString describerType, int viewId) const
     return count;
 }
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision
 
 #include "MTracks.moc"

--- a/src/qtAliceVision/MTracks.hpp
+++ b/src/qtAliceVision/MTracks.hpp
@@ -10,17 +10,16 @@
 #include <string>
 #include <vector>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 /**
  * @brief QObject wrapper around Tracks.
- * 
+ *
  * Given a folder containing feature matches,
  * the role of an MTracks instance is to load the matches from disk
  * and build the corresponding tracks.
  * These tasks are done asynchronously to avoid freezing the UI.
- * 
+ *
  * MTracks objects are accessible from QML
  * and can be manipulated through their properties.
  */
@@ -37,7 +36,7 @@ class MTracks : public QObject
 
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
 
-public:
+  public:
     /// Status Enum
 
     enum Status
@@ -53,10 +52,10 @@ public:
     MTracks& operator=(const MTracks& other) = default;
     ~MTracks() override;
 
-private:
+  private:
     MTracks(const MTracks& other);
 
-public:
+  public:
     /// Slots
 
     Q_SLOT void load();
@@ -72,7 +71,7 @@ public:
 
     Q_INVOKABLE int nbMatches(QString describerType, int viewId) const;
 
-public:
+  public:
     const aliceVision::track::TracksMap* tracksPtr() const { return _tracks; }
     const aliceVision::track::TracksMap& tracks() const { return *_tracks; }
     const aliceVision::track::TracksPerView& tracksPerView() const { return *_tracksPerView; }
@@ -80,7 +79,7 @@ public:
     Status status() const { return _status; }
     void setStatus(Status status);
 
-private:
+  private:
     /// Private members
 
     QVariantList _matchingFolders;
@@ -99,19 +98,17 @@ class TracksIORunnable : public QObject, public QRunnable
 {
     Q_OBJECT
 
-public:
+  public:
     explicit TracksIORunnable(const std::vector<std::string>& folders)
-        : _folders(folders)
-    {
-    }
+      : _folders(folders)
+    {}
 
     Q_SLOT void run() override;
 
-    Q_SIGNAL void resultReady(aliceVision::track::TracksMap* tracks,
-                              aliceVision::track::TracksPerView* tracksPerView);
+    Q_SIGNAL void resultReady(aliceVision::track::TracksMap* tracks, aliceVision::track::TracksPerView* tracksPerView);
 
-private:
+  private:
     std::vector<std::string> _folders;
 };
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/MViewStats.cpp
+++ b/src/qtAliceVision/MViewStats.cpp
@@ -7,8 +7,7 @@
 #include <algorithm>
 #include <math.h>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 void MViewStats::fillResidualFullSerie(QXYSeries* residuals)
 {
@@ -241,8 +240,7 @@ void MViewStats::computeViewStats()
             std::vector<size_t>& residualFullHistY = _residualHistogramFull.GetHist();
             for (std::size_t i = 0; i < residualFullHistY.size(); ++i)
             {
-                residualFullHistY[i] =
-                    static_cast<size_t>(round(static_cast<double>(residualFullHistY[i]) / nbCameras));
+                residualFullHistY[i] = static_cast<size_t>(round(static_cast<double>(residualFullHistY[i]) / nbCameras));
             }
             std::vector<double> residualHistX = _residualHistogramFull.GetXbinsValue();
             assert(residualHistX.size() == residualFullHistY.size());
@@ -276,8 +274,8 @@ void MViewStats::computeViewStats()
         {
             // observationsLengths histogram of all views
             BoxStats<double> observationsLengthsFullStats;
-            sfm::computeObservationsLengthsHistogram(_msfmData->rawData(), observationsLengthsFullStats,
-                                                     _nbObservations, &_observationsLengthsHistogramFull);
+            sfm::computeObservationsLengthsHistogram(
+              _msfmData->rawData(), observationsLengthsFullStats, _nbObservations, &_observationsLengthsHistogramFull);
 
             double nbCameras = double(_msfmData->nbCameras());
             std::vector<size_t>& observationsLengthsFullHistY = _observationsLengthsHistogramFull.GetHist();
@@ -285,34 +283,29 @@ void MViewStats::computeViewStats()
             // normalize the histogram to get the average number of observations
             for (std::size_t i = 0; i < observationsLengthsFullHistY.size(); ++i)
             {
-                observationsLengthsFullHistY[i] =
-                    static_cast<size_t>(round(static_cast<double>(observationsLengthsFullHistY[i]) / nbCameras));
+                observationsLengthsFullHistY[i] = static_cast<size_t>(round(static_cast<double>(observationsLengthsFullHistY[i]) / nbCameras));
             }
             std::vector<double> observationsLengthsHistX = _observationsLengthsHistogramFull.GetXbinsValue();
             assert(observationsLengthsHistX.size() == observationsLengthsFullHistY.size());
             for (std::size_t i = 0; i < observationsLengthsFullHistY.size(); ++i)
             {
-                _observationsLengthsMaxAxisX =
-                    round(std::max(_observationsLengthsMaxAxisX, observationsLengthsHistX[i]));
-                _observationsLengthsMaxAxisY =
-                    round(std::max(_observationsLengthsMaxAxisY, double(observationsLengthsFullHistY[i])));
+                _observationsLengthsMaxAxisX = round(std::max(_observationsLengthsMaxAxisX, observationsLengthsHistX[i]));
+                _observationsLengthsMaxAxisY = round(std::max(_observationsLengthsMaxAxisY, double(observationsLengthsFullHistY[i])));
             }
         }
         {
             // observationsLengths histogram of current view
             BoxStats<double> observationsLengthsViewStats;
-            sfm::computeObservationsLengthsHistogram(_msfmData->rawData(), observationsLengthsViewStats,
-                                                     _nbObservations, &_observationsLengthsHistogramView, {_viewId});
+            sfm::computeObservationsLengthsHistogram(
+              _msfmData->rawData(), observationsLengthsViewStats, _nbObservations, &_observationsLengthsHistogramView, {_viewId});
             std::vector<size_t> observationsLengthsViewHistY = _observationsLengthsHistogramView.GetHist();
             std::vector<double> observationsLengthsHistX = _observationsLengthsHistogramView.GetXbinsValue();
             assert(observationsLengthsHistX.size() == observationsLengthsViewHistY.size());
 
             for (std::size_t i = 0; i < observationsLengthsViewHistY.size(); ++i)
             {
-                _observationsLengthsMaxAxisX =
-                    round(std::max(_observationsLengthsMaxAxisX, observationsLengthsHistX[i]));
-                _observationsLengthsMaxAxisY =
-                    round(std::max(_observationsLengthsMaxAxisY, double(observationsLengthsViewHistY[i])));
+                _observationsLengthsMaxAxisX = round(std::max(_observationsLengthsMaxAxisX, observationsLengthsHistX[i]));
+                _observationsLengthsMaxAxisY = round(std::max(_observationsLengthsMaxAxisY, double(observationsLengthsViewHistY[i])));
             }
         }
     }
@@ -329,16 +322,14 @@ void MViewStats::computeViewStats()
         std::vector<size_t>& observationsScaleFullHistY = _observationsScaleHistogramFull.GetHist();
         for (std::size_t i = 0; i < observationsScaleFullHistY.size(); ++i)
         {
-            observationsScaleFullHistY[i] =
-                static_cast<std::size_t>(std::round(static_cast<double>(observationsScaleFullHistY[i]) / nbCameras));
+            observationsScaleFullHistY[i] = static_cast<std::size_t>(std::round(static_cast<double>(observationsScaleFullHistY[i]) / nbCameras));
         }
         std::vector<double> observationsScaleHistX = _observationsScaleHistogramFull.GetXbinsValue();
         assert(observationsScaleHistX.size() == observationsScaleFullHistY.size());
 
         // histrogram of observations Scale of current view
         BoxStats<double> observationsScaleViewStats;
-        sfm::computeScaleHistogram(_msfmData->rawData(), observationsScaleViewStats, &_observationsScaleHistogramView,
-                                   {_viewId});
+        sfm::computeScaleHistogram(_msfmData->rawData(), observationsScaleViewStats, &_observationsScaleHistogramView, {_viewId});
         std::vector<size_t> observationsScaleViewHistY = _observationsScaleHistogramView.GetHist();
         assert(observationsScaleHistX.size() == observationsScaleViewHistY.size());
 
@@ -348,13 +339,11 @@ void MViewStats::computeViewStats()
         for (std::size_t i = 0; i < observationsScaleHistX.size(); ++i)
         {
             _observationsScaleMaxAxisX = round(std::max(_observationsScaleMaxAxisX, observationsScaleHistX[i]));
-            _observationsScaleMaxAxisY =
-                round(std::max(_observationsScaleMaxAxisY, double(observationsScaleFullHistY[i])));
+            _observationsScaleMaxAxisY = round(std::max(_observationsScaleMaxAxisY, double(observationsScaleFullHistY[i])));
         }
         for (std::size_t i = 0; i < observationsScaleViewHistY.size(); ++i)
         {
-            _observationsScaleMaxAxisY =
-                round(std::max(_observationsScaleMaxAxisY, double(observationsScaleViewHistY[i])));
+            _observationsScaleMaxAxisY = round(std::max(_observationsScaleMaxAxisY, double(observationsScaleViewHistY[i])));
         }
     }
 
@@ -375,4 +364,4 @@ void MViewStats::setMSfmData(qtAliceVision::MSfMData* sfmData)
     Q_EMIT sfmDataChanged();
 }
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/MViewStats.hpp
+++ b/src/qtAliceVision/MViewStats.hpp
@@ -12,8 +12,7 @@
 #include <aliceVision/utils/Histogram.hpp>
 #include <MSfMData.hpp>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 QT_CHARTS_USE_NAMESPACE
 
@@ -37,7 +36,7 @@ class MViewStats : public QObject
     /// max AxisY value for scale histogram
     Q_PROPERTY(double observationsScaleMaxAxisY MEMBER _observationsScaleMaxAxisY NOTIFY viewStatsChanged)
 
-public:
+  public:
     MViewStats()
     {
         connect(this, &MViewStats::sfmDataChanged, this, &MViewStats::computeViewStats);
@@ -64,7 +63,7 @@ public:
     MSfMData* getMSfmData() { return _msfmData; }
     void setMSfmData(qtAliceVision::MSfMData* sfmData);
 
-private:
+  private:
     aliceVision::utils::Histogram<double> _residualHistogramFull;
     aliceVision::utils::Histogram<double> _residualHistogramView;
     aliceVision::utils::Histogram<double> _observationsLengthsHistogramFull;
@@ -82,6 +81,6 @@ private:
     aliceVision::IndexT _viewId = aliceVision::UndefinedIndexT;
 };
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision
 
-Q_DECLARE_METATYPE(QPointF) // for usage in signals/slots/properties
+Q_DECLARE_METATYPE(QPointF)  // for usage in signals/slots/properties

--- a/src/qtAliceVision/Painter.cpp
+++ b/src/qtAliceVision/Painter.cpp
@@ -4,13 +4,11 @@
 #include <QSGGeometry>
 #include <QtDebug>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 Painter::Painter(const std::vector<std::string>& layers)
-    : _layers(layers)
-{
-}
+  : _layers(layers)
+{}
 
 int Painter::layerIndex(const std::string& layer) const
 {
@@ -85,8 +83,7 @@ void Painter::clearLayer(QSGNode* node, const std::string& layer) const
     geometry->allocate(0, 0);
 }
 
-void Painter::drawPoints(QSGNode* node, const std::string& layer, const std::vector<QPointF>& points,
-                         const QColor& color, float pointSize) const
+void Painter::drawPoints(QSGNode* node, const std::string& layer, const std::vector<QPointF>& points, const QColor& color, float pointSize) const
 {
     auto* root = getGeometryNode(node, layer);
     if (!root)
@@ -125,8 +122,7 @@ void Painter::drawPoints(QSGNode* node, const std::string& layer, const std::vec
     material->setColor(color);
 }
 
-void Painter::drawLines(QSGNode* node, const std::string& layer, const std::vector<QPointF>& points,
-                        const QColor& color, float lineWidth) const
+void Painter::drawLines(QSGNode* node, const std::string& layer, const std::vector<QPointF>& points, const QColor& color, float lineWidth) const
 {
     auto* root = getGeometryNode(node, layer);
     if (!root)
@@ -165,8 +161,7 @@ void Painter::drawLines(QSGNode* node, const std::string& layer, const std::vect
     material->setColor(color);
 }
 
-void Painter::drawTriangles(QSGNode* node, const std::string& layer, const std::vector<QPointF>& points,
-                            const QColor& color) const
+void Painter::drawTriangles(QSGNode* node, const std::string& layer, const std::vector<QPointF>& points, const QColor& color) const
 {
     auto* root = getGeometryNode(node, layer);
     if (!root)
@@ -204,4 +199,4 @@ void Painter::drawTriangles(QSGNode* node, const std::string& layer, const std::
     material->setColor(color);
 }
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/Painter.hpp
+++ b/src/qtAliceVision/Painter.hpp
@@ -8,8 +8,7 @@
 #include <string>
 #include <vector>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 /**
  * @brief Utility class for abstracting the painting mechanisms in the Qt scene graph.
@@ -21,7 +20,7 @@ namespace qtAliceVision
  */
 class Painter
 {
-public:
+  public:
     /**
      * @brief Construct a Painter object with the given layers.
      * @param layers Layer names ordered from first to last drawn.
@@ -43,8 +42,7 @@ public:
      * @param color Points color (same for all points).
      * @param pointSize Points size (same for all points).
      */
-    void drawPoints(QSGNode* node, const std::string& layer, const std::vector<QPointF>& points, const QColor& color,
-                    float pointSize) const;
+    void drawPoints(QSGNode* node, const std::string& layer, const std::vector<QPointF>& points, const QColor& color, float pointSize) const;
 
     /**
      * @brief Clear a layer and draw lines on it.
@@ -54,8 +52,7 @@ public:
      * @param color Lines color (same for all lines).
      * @param lineWidth Lines width (same for all lines).
      */
-    void drawLines(QSGNode* node, const std::string& layer, const std::vector<QPointF>& points, const QColor& color,
-                   float lineWidth) const;
+    void drawLines(QSGNode* node, const std::string& layer, const std::vector<QPointF>& points, const QColor& color, float lineWidth) const;
 
     /**
      * @brief Clear a layer and draw triangles on it.
@@ -64,10 +61,9 @@ public:
      * @param points Triangle corners as 2D points.
      * @param color Triangles color (same for all triangles).
      */
-    void drawTriangles(QSGNode* node, const std::string& layer, const std::vector<QPointF>& points,
-                       const QColor& color) const;
+    void drawTriangles(QSGNode* node, const std::string& layer, const std::vector<QPointF>& points, const QColor& color) const;
 
-private:
+  private:
     /// Layers stack, ordered from first to last drawn.
     std::vector<std::string> _layers;
 
@@ -94,4 +90,4 @@ private:
     QSGGeometryNode* getGeometryNode(QSGNode* node, const std::string& layer) const;
 };
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/PanoramaViewer.cpp
+++ b/src/qtAliceVision/PanoramaViewer.cpp
@@ -17,10 +17,9 @@
 
 #include <aliceVision/system/MemoryInfo.hpp>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 PanoramaViewer::PanoramaViewer(QQuickItem* parent)
-    : QQuickItem(parent)
+  : QQuickItem(parent)
 {
     setFlag(QQuickItem::ItemHasContents, true);
     connect(this, &PanoramaViewer::sourceSizeChanged, this, &PanoramaViewer::update);
@@ -37,8 +36,7 @@ void PanoramaViewer::computeDownscale()
 
     int totalSizeImages = 0;
     for (const auto& view : _msfmData->rawData().getViews())
-        totalSizeImages +=
-            int(static_cast<double>((view.second->getImage().getWidth() * view.second->getImage().getHeight()) * 4) / std::pow(10, 6));
+        totalSizeImages += int(static_cast<double>((view.second->getImage().getWidth() * view.second->getImage().getHeight()) * 4) / std::pow(10, 6));
 
     // Downscale = 4 by default
     _downscale = 4;
@@ -59,7 +57,7 @@ void PanoramaViewer::computeDownscale()
 
 QSGNode* PanoramaViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdatePaintNodeData* data)
 {
-    (void)data; // Fix "unused parameter" warnings; should be replaced by [[maybe_unused]] when C++17 is supported
+    (void)data;  // Fix "unused parameter" warnings; should be replaced by [[maybe_unused]] when C++17 is supported
     QSGGeometryNode* root = static_cast<QSGGeometryNode*>(oldNode);
     return root;
 }
@@ -95,4 +93,4 @@ void PanoramaViewer::setMSfmData(MSfMData* sfmData)
     }
 }
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/PanoramaViewer.hpp
+++ b/src/qtAliceVision/PanoramaViewer.hpp
@@ -18,8 +18,7 @@
 #include <memory>
 #include <string>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 /**
  * @brief Displays a list of Float Images.
  */
@@ -32,7 +31,7 @@ class PanoramaViewer : public QQuickItem
 
     Q_PROPERTY(int downscale MEMBER _downscale NOTIFY downscaleChanged)
 
-public:
+  public:
     explicit PanoramaViewer(QQuickItem* parent = nullptr);
     ~PanoramaViewer() override;
 
@@ -43,7 +42,7 @@ public:
 
     Q_SLOT void msfmDataUpdate() { computeDownscale(); }
 
-public:
+  public:
     Q_SIGNAL void sourceSizeChanged();
 
     Q_SIGNAL void sfmDataChanged();
@@ -52,13 +51,13 @@ public:
 
     Q_SIGNAL void downscaleReady();
 
-private:
+  private:
     /// Custom QSGNode update
     QSGNode* updatePaintNode(QSGNode* oldNode, QQuickItem::UpdatePaintNodeData* data) override;
 
     void computeDownscale();
 
-private:
+  private:
     QSize _sourceSize = QSize(3000, 1500);
 
     MSfMData* _msfmData = nullptr;
@@ -66,6 +65,6 @@ private:
     int _downscale = 4;
 };
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision
 
 Q_DECLARE_METATYPE(QList<QPoint>)

--- a/src/qtAliceVision/SequenceCache.hpp
+++ b/src/qtAliceVision/SequenceCache.hpp
@@ -20,15 +20,14 @@
 #include <memory>
 #include <cstdint>
 
-
 namespace qtAliceVision {
 namespace imgserve {
 
 /**
  * @brief Utility struct for manipulating various information about a given frame.
  */
-struct FrameData {
-
+struct FrameData
+{
     std::string path;
 
     QSize dim;
@@ -38,35 +37,32 @@ struct FrameData {
     int frame;
 
     int downscale;
-
 };
 
 /**
  * @brief Image server with a caching system for loading image sequences from disk.
- * 
+ *
  * Given a sequence of images (ordered by filename), the SequenceCache works as an image server:
  * it receives requests from clients (in the form of a filepath)
  * and its purpose is to provide the corresponding images (if they exist in the sequence).
- * 
+ *
  * The SequenceCache takes advantage of the ordering of the sequence to load whole "regions" at once
  * (a region being a contiguous range of images from the sequence).
  * Such strategy makes sense under the assumption that the sequence order is meaningful for clients,
  * i.e. that if an image is queried then it is likely that the next queries will be close in the sequence.
  */
-class SequenceCache : public QObject, public ImageServer {
-
+class SequenceCache : public QObject, public ImageServer
+{
     Q_OBJECT
 
-public:
-
+  public:
     // Constructors and destructor
 
     explicit SequenceCache(QObject* parent = nullptr);
 
     ~SequenceCache();
 
-public:
-
+  public:
     // Data manipulation for the Qt property system
 
     /**
@@ -95,8 +91,7 @@ public:
      */
     QVariantList getCachedFrames() const;
 
-public:
-
+  public:
     // Request management
 
     /// If the image requested falls outside a certain region of cached images,
@@ -126,8 +121,7 @@ public:
      */
     Q_SIGNAL void contentChanged();
 
-private:
-
+  private:
     // Member variables
 
     /// Ordered sequence of frames.
@@ -157,8 +151,7 @@ private:
     /// sequence mutex
     QMutex _lockSequence;
 
-private:
-
+  private:
     // Utility methods
 
     /**
@@ -175,18 +168,16 @@ private:
      * @return an interval of size 2*extent that fits in the sequence and contains the given frame
      */
     std::pair<int, int> buildRegion(int frame, int extent) const;
-
 };
 
 /**
  * @brief Utility class for loading images from disk to cache asynchronously.
  */
-class PrefetchingIORunnable : public QObject, public QRunnable {
-
+class PrefetchingIORunnable : public QObject, public QRunnable
+{
     Q_OBJECT
 
-public:
-
+  public:
     /**
      * @param[in] cache pointer to image cache to fill
      * @param[in] toLoad sequence frames to load from disk
@@ -218,8 +209,7 @@ public:
      */
     Q_SIGNAL void done(int sequenceId, int reqFrame);
 
-private:
-
+  private:
     /// Image cache to fill.
     aliceVision::image::ImageCache* _cache;
 
@@ -236,5 +226,5 @@ private:
     int _sequenceId;
 };
 
-} // namespace imgserve
-} // namespace qtAliceVision
+}  // namespace imgserve
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/ShaderImageViewer.hpp
+++ b/src/qtAliceVision/ShaderImageViewer.hpp
@@ -8,10 +8,8 @@
 #include <QSGSimpleMaterialShader>
 #include <QSGTexture>
 
-namespace qtAliceVision
-{
-namespace
-{
+namespace qtAliceVision {
+namespace {
 struct ShaderData
 {
     float gamma = 1.f;
@@ -27,7 +25,7 @@ class ImageViewerShader : public QSGSimpleMaterialShader<ShaderData>
 {
     QSG_DECLARE_SIMPLE_SHADER(ImageViewerShader, ShaderData)
 
-public:
+  public:
     const char* vertexShader() const override
     {
         return "attribute highp vec4 vertex;               \n"
@@ -103,7 +101,7 @@ public:
         program()->setUniformValue(_textureId, 0);
     }
 
-private:
+  private:
     int _textureId = -1;
     int _gammaId = -1;
     int _gainId = -1;
@@ -113,6 +111,6 @@ private:
     int _aspectRatio = -1;
 };
 
-} // namespace
+}  // namespace
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/SingleImageLoader.cpp
+++ b/src/qtAliceVision/SingleImageLoader.cpp
@@ -5,66 +5,63 @@
 #include <stdexcept>
 #include <iostream>
 
-
 namespace qtAliceVision {
 namespace imgserve {
 
-SingleImageLoader::SingleImageLoader(QObject* parent) : 
-	QObject(parent)
+SingleImageLoader::SingleImageLoader(QObject* parent)
+  : QObject(parent)
 {
-	// Initialize internal state
-	_loading = false;
+    // Initialize internal state
+    _loading = false;
 }
 
-SingleImageLoader::~SingleImageLoader()
-{}
+SingleImageLoader::~SingleImageLoader() {}
 
 ResponseData SingleImageLoader::request(const RequestData& reqData)
 {
-	// Check if requested image matches currently loaded image
-	if (reqData.path == _request.path && reqData.downscale == _request.downscale)
-	{
-		return _response;
-	}
+    // Check if requested image matches currently loaded image
+    if (reqData.path == _request.path && reqData.downscale == _request.downscale)
+    {
+        return _response;
+    }
 
-	// If there is not already a worker thread
-	// start a new one using the currently requested image
-	if (!_loading)
-	{
-		// Update internal state
-		_loading = true;
+    // If there is not already a worker thread
+    // start a new one using the currently requested image
+    if (!_loading)
+    {
+        // Update internal state
+        _loading = true;
 
-		// Create new runnable and launch it in worker thread (managed by Qt thread pool)
-		auto ioRunnable = new SingleImageLoadingIORunnable(reqData);
+        // Create new runnable and launch it in worker thread (managed by Qt thread pool)
+        auto ioRunnable = new SingleImageLoadingIORunnable(reqData);
         connect(ioRunnable, &SingleImageLoadingIORunnable::done, this, &SingleImageLoader::onSingleImageLoadingDone);
         QThreadPool::globalInstance()->start(ioRunnable);
-	}
+    }
 
-	// Empty response
-	return ResponseData();
+    // Empty response
+    return ResponseData();
 }
 
 void SingleImageLoader::onSingleImageLoadingDone(RequestData reqData, ResponseData response)
 {
-	// Update internal state
-	_loading = false;
-	_request = reqData;
-	_response = response;
+    // Update internal state
+    _loading = false;
+    _request = reqData;
+    _response = response;
 
-	// Notify listeners that an image has been loaded
-	Q_EMIT requestHandled();
+    // Notify listeners that an image has been loaded
+    Q_EMIT requestHandled();
 }
 
-SingleImageLoadingIORunnable::SingleImageLoadingIORunnable(const RequestData& reqData) : 
-	_reqData(reqData)
+SingleImageLoadingIORunnable::SingleImageLoadingIORunnable(const RequestData& reqData)
+  : _reqData(reqData)
 {}
 
-SingleImageLoadingIORunnable::~SingleImageLoadingIORunnable()
-{}
+SingleImageLoadingIORunnable::~SingleImageLoadingIORunnable() {}
 
 void SingleImageLoadingIORunnable::run()
 {
-	ResponseData response;
+    ResponseData response;
 
     try
     {
@@ -101,7 +98,7 @@ void SingleImageLoadingIORunnable::run()
     Q_EMIT done(_reqData, response);
 }
 
-} // namespace imgserve
-} // namespace qtAliceVision
+}  // namespace imgserve
+}  // namespace qtAliceVision
 
 #include "SingleImageLoader.moc"

--- a/src/qtAliceVision/SingleImageLoader.hpp
+++ b/src/qtAliceVision/SingleImageLoader.hpp
@@ -8,92 +8,84 @@
 
 #include <string>
 
-
 namespace qtAliceVision {
 namespace imgserve {
 
 /**
  * @brief Image server that can load a single image at a time.
  */
-class SingleImageLoader : public QObject, public ImageServer {
+class SingleImageLoader : public QObject, public ImageServer
+{
+    Q_OBJECT
 
-	Q_OBJECT
+  public:
+    // Constructors and destructor
 
-public:
+    explicit SingleImageLoader(QObject* parent = nullptr);
 
-	// Constructors and destructor
+    ~SingleImageLoader();
 
-	explicit SingleImageLoader(QObject* parent = nullptr);
+  public:
+    // Request management
 
-	~SingleImageLoader();
+    /// If the image requested cannot be retrieved immediatly,
+    /// this method will launch a worker thread to load it from disk.
+    ResponseData request(const RequestData& reqData) override;
 
-public:
+    /**
+     * @brief Slot called when the loading thread is done.
+     * @param[in] reqData request data used to create the loading thread
+     * @param[in] response a ResponseData instance containing the data loaded from disk
+     */
+    Q_SLOT void onSingleImageLoadingDone(RequestData reqData, ResponseData response);
 
-	// Request management
+    /**
+     * @brief Signal emitted when the loading thread is done and a previous request has been handled.
+     */
+    Q_SIGNAL void requestHandled();
 
-	/// If the image requested cannot be retrieved immediatly,
-	/// this method will launch a worker thread to load it from disk.
-	ResponseData request(const RequestData& reqData) override;
+  private:
+    // Member variables
 
-	/**
-	 * @brief Slot called when the loading thread is done.
-	 * @param[in] reqData request data used to create the loading thread
-	 * @param[in] response a ResponseData instance containing the data loaded from disk
-	 */
-	Q_SLOT void onSingleImageLoadingDone(RequestData reqData, ResponseData response);
+    /// Latest request data.
+    RequestData _request;
 
-	/**
-	 * @brief Signal emitted when the loading thread is done and a previous request has been handled.
-	 */
-	Q_SIGNAL void requestHandled();
+    /// Latest response data.
+    ResponseData _response;
 
-private:
-
-	// Member variables
-
-	/// Latest request data.
-	RequestData _request;
-
-	/// Latest response data.
-	ResponseData _response;
-
-	/// Keep track of whether or not there is an active worker thread.
-	bool _loading;
-
+    /// Keep track of whether or not there is an active worker thread.
+    bool _loading;
 };
 
 /**
  * @brief Utility class for loading a single image asynchronously.
  */
-class SingleImageLoadingIORunnable : public QObject, public QRunnable {
+class SingleImageLoadingIORunnable : public QObject, public QRunnable
+{
+    Q_OBJECT
 
-	Q_OBJECT
+  public:
+    /**
+     * @param[in] path filepath of the image to load
+     */
+    explicit SingleImageLoadingIORunnable(const RequestData& reqData);
 
-public:
+    ~SingleImageLoadingIORunnable();
 
-	/**
-	 * @param[in] path filepath of the image to load
-	 */
-	explicit SingleImageLoadingIORunnable(const RequestData& reqData);
+    /// Main method for loading a single image in a worker thread.
+    Q_SLOT void run() override;
 
-	~SingleImageLoadingIORunnable();
+    /**
+     * @brief Signal emitted when image loading is finished.
+     * @param[in] reqData request data used to create the loading thread
+     * @param[in] response a ResponseData instance containing the data loaded from disk
+     */
+    Q_SIGNAL void done(RequestData reqData, ResponseData response);
 
-	/// Main method for loading a single image in a worker thread.
-	Q_SLOT void run() override;
-
-	/**
-	 * @brief Signal emitted when image loading is finished.
-	 * @param[in] reqData request data used to create the loading thread
-	 * @param[in] response a ResponseData instance containing the data loaded from disk
-	 */
-	Q_SIGNAL void done(RequestData reqData, ResponseData response);
-
-private:
-
-	/// Request data of image to load.
-	RequestData _reqData;
-
+  private:
+    /// Request data of image to load.
+    RequestData _reqData;
 };
 
-} // namespace imgserve
-} // namespace qtAliceVision
+}  // namespace imgserve
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/Surface.cpp
+++ b/src/qtAliceVision/Surface.cpp
@@ -11,8 +11,7 @@
 #include <math.h>
 #include <memory>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 aliceVision::Vec2 toEquirectangular(const aliceVision::Vec3& spherical, int width, int height)
 {
@@ -26,7 +25,7 @@ aliceVision::Vec2 toEquirectangular(const aliceVision::Vec3& spherical, int widt
 }
 
 Surface::Surface(int subdivisions, QObject* parent)
-    : QObject(parent)
+  : QObject(parent)
 {
     updateSubdivisions(subdivisions);
     connect(this, &Surface::sfmDataChanged, this, &Surface::msfmDataUpdate);
@@ -46,8 +45,7 @@ void Surface::update(QSGGeometry::TexturedPoint2D* vertices, quint16* indices, Q
 }
 
 // GRID METHODS
-void Surface::computeGrid(QSGGeometry::TexturedPoint2D* vertices, quint16* indices, QSize textureSize,
-                          int downscaleLevel)
+void Surface::computeGrid(QSGGeometry::TexturedPoint2D* vertices, quint16* indices, QSize textureSize, int downscaleLevel)
 {
     aliceVision::camera::IntrinsicBase* intrinsic = nullptr;
     bool verticesComputed = false;
@@ -113,17 +111,17 @@ void Surface::computeGrid(QSGGeometry* geometryLine)
             }
 
             // Vertical Lines
-            geometryLine->vertexDataAsPoint2D()[countPoint++].set(static_cast<float>(_vertices[index].x()),
-                                                                  static_cast<float>(_vertices[index].y()));
+            geometryLine->vertexDataAsPoint2D()[countPoint++].set(static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
             index++;
-            geometryLine->vertexDataAsPoint2D()[countPoint++].set(static_cast<float>(_vertices[index].x()),
-                                                                  static_cast<float>(_vertices[index].y()));
+            geometryLine->vertexDataAsPoint2D()[countPoint++].set(static_cast<float>(_vertices[index].x()), static_cast<float>(_vertices[index].y()));
         }
     }
 }
 
-void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize textureSize,
-                                  aliceVision::camera::IntrinsicBase* intrinsic, int downscaleLevel)
+void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices,
+                                  QSize textureSize,
+                                  aliceVision::camera::IntrinsicBase* intrinsic,
+                                  int downscaleLevel)
 {
     // Retrieve pose if Panorama Viewer is enable
     if (isPanoramaViewerEnabled() && intrinsic)
@@ -209,8 +207,7 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
                     // Image System Coordinates
                     aliceVision::Vec2 uvCoord(x, y);
                     const auto& transfromPose = pose.getTransform();
-                    _defaultSphereCoordinates.push_back(
-                        aliceVision::camera::applyIntrinsicExtrinsic(transfromPose, intrinsic, uvCoord));
+                    _defaultSphereCoordinates.push_back(aliceVision::camera::applyIntrinsicExtrinsic(transfromPose, intrinsic, uvCoord));
                 }
 
                 // Rotate Panorama if some rotation values exist
@@ -218,8 +215,7 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
                 rotatePanorama(sphereCoordinates);
 
                 // Compute pixel coordinates in the panorama coordinate system
-                aliceVision::Vec2 panoramaCoordinates =
-                    toEquirectangular(sphereCoordinates, _panoramaWidth, _panoramaHeight);
+                aliceVision::Vec2 panoramaCoordinates = toEquirectangular(sphereCoordinates, _panoramaWidth, _panoramaHeight);
 
                 // If image is on the seam
                 if (vertexIndex > 0 && j > 0)
@@ -238,8 +234,7 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize 
                         _vertexEnabled[i][j - 1] = false;
                     }
                 }
-                vertices[vertexIndex].set(static_cast<float>(panoramaCoordinates.x()),
-                                          static_cast<float>(panoramaCoordinates.y()), u, v);
+                vertices[vertexIndex].set(static_cast<float>(panoramaCoordinates.x()), static_cast<float>(panoramaCoordinates.y()), u, v);
             }
 
             // Default
@@ -595,19 +590,10 @@ void Surface::setViewerType(EViewerType type)
     Q_EMIT viewerTypeChanged();
 }
 
-bool Surface::isPanoramaViewerEnabled() const
-{
-    return _viewerType == EViewerType::PANORAMA;
-}
+bool Surface::isPanoramaViewerEnabled() const { return _viewerType == EViewerType::PANORAMA; }
 
-bool Surface::isDistortionViewerEnabled() const
-{
-    return _viewerType == EViewerType::DISTORTION;
-}
-bool Surface::isHDRViewerEnabled() const
-{
-    return _viewerType == EViewerType::HDR;
-}
+bool Surface::isDistortionViewerEnabled() const { return _viewerType == EViewerType::DISTORTION; }
+bool Surface::isHDRViewerEnabled() const { return _viewerType == EViewerType::HDR; }
 
 void Surface::setMSfmData(MSfMData* sfmData)
 {
@@ -674,10 +660,9 @@ const aliceVision::camera::Equidistant* Surface::getIntrinsicEquidistant() const
     }
 
     // Load equidistant intrinsic (the intrinsic for full circle fisheye cameras)
-    const aliceVision::camera::Equidistant* intrinsicEquidistant =
-        dynamic_cast<const aliceVision::camera::Equidistant*>(intrinsic);
+    const aliceVision::camera::Equidistant* intrinsicEquidistant = dynamic_cast<const aliceVision::camera::Equidistant*>(intrinsic);
 
     return intrinsicEquidistant;
 }
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/Surface.hpp
+++ b/src/qtAliceVision/Surface.hpp
@@ -11,8 +11,7 @@
 #include <aliceVision/camera/IntrinsicBase.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 /**
  * @brief Discretization of FloatImageViewer surface
@@ -43,7 +42,7 @@ class Surface : public QObject
     Q_PROPERTY(double pitch READ getPitch WRITE setPitch NOTIFY anglesChanged)
     Q_PROPERTY(double roll READ getRoll WRITE setRoll NOTIFY anglesChanged)
 
-public:
+  public:
     Surface(int subdivisions = 12, QObject* parent = nullptr);
     Surface& operator=(const Surface& other) = default;
     ~Surface();
@@ -151,14 +150,15 @@ public:
 
     const aliceVision::camera::Equidistant* getIntrinsicEquidistant() const;
 
-private:
+  private:
     aliceVision::camera::IntrinsicBase* getIntrinsicFromViewId(unsigned int viewId) const;
 
-    void computeGrid(QSGGeometry::TexturedPoint2D* vertices, quint16* indices, QSize textureSize,
-                     int downscaleLevel = 0);
+    void computeGrid(QSGGeometry::TexturedPoint2D* vertices, quint16* indices, QSize textureSize, int downscaleLevel = 0);
 
-    void computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices, QSize textureSize,
-                             aliceVision::camera::IntrinsicBase* intrinsic, int downscaleLevel = 0);
+    void computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices,
+                             QSize textureSize,
+                             aliceVision::camera::IntrinsicBase* intrinsic,
+                             int downscaleLevel = 0);
 
     void computeIndicesGrid(quint16* indices);
 
@@ -173,7 +173,7 @@ private:
     // Get pitch / yaw / roll in radians and return degrees angle in the correct interval
     double getEulerAngleDegrees(double angleRadians);
 
-private:
+  private:
     const int _panoramaWidth = 3000;
     const int _panoramaHeight = 1500;
 
@@ -221,4 +221,4 @@ private:
     bool _isPanoramaRotating = false;
 };
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVision/plugin.hpp
+++ b/src/qtAliceVision/plugin.hpp
@@ -18,15 +18,14 @@
 
 #include <memory>
 
-namespace qtAliceVision
-{
+namespace qtAliceVision {
 
 class QtAliceVisionPlugin : public QQmlExtensionPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "qtAliceVision.qmlPlugin")
 
-public:
+  public:
     void initializeEngine(QQmlEngine* engine, const char* uri) override
     {
         // Fix "unused parameter" warnings; should be replaced by [[maybe_unused]] when C++17 is supported
@@ -47,9 +46,8 @@ public:
         qmlRegisterType<MSfMDataStats>(uri, 1, 0, "MSfMDataStats");
         qRegisterMetaType<QList<QPointF*>>("QList<QPointF*>");
         qRegisterMetaType<QQmlListProperty<QPointF>>("QQmlListProperty<QPointF>");
-        qRegisterMetaType<aliceVision::sfmData::SfMData>(
-            "QSharedPtr<aliceVision::sfmData::SfMData>"); // for usage in signals/slots
-        qRegisterMetaType<size_t>("size_t");              // for usage in signals/slots
+        qRegisterMetaType<aliceVision::sfmData::SfMData>("QSharedPtr<aliceVision::sfmData::SfMData>");  // for usage in signals/slots
+        qRegisterMetaType<size_t>("size_t");                                                            // for usage in signals/slots
 
         qmlRegisterType<FloatImageViewer>(uri, 1, 0, "FloatImageViewer");
         qmlRegisterType<Surface>(uri, 1, 0, "Surface");
@@ -67,4 +65,4 @@ public:
     }
 };
 
-} // namespace qtAliceVision
+}  // namespace qtAliceVision

--- a/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.cpp
+++ b/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.cpp
@@ -24,15 +24,9 @@ inline const float& clamp(const float& v, const float& lo, const float& hi)
     return (v < lo) ? lo : (hi < v) ? hi : v;
 }
 
-inline unsigned short floatToUShort(float v)
-{
-    return static_cast<unsigned short>(clamp(v, 0.0f, 1.0f) * 65535);
-}
+inline unsigned short floatToUShort(float v) { return static_cast<unsigned short>(clamp(v, 0.0f, 1.0f) * 65535); }
 
-QtAliceVisionImageIOHandler::QtAliceVisionImageIOHandler()
-{
-    qDebug() << "[QtAliceVisionImageIO] QtAliceVisionImageIOHandler";
-}
+QtAliceVisionImageIOHandler::QtAliceVisionImageIOHandler() { qDebug() << "[QtAliceVisionImageIO] QtAliceVisionImageIOHandler"; }
 
 QtAliceVisionImageIOHandler::~QtAliceVisionImageIOHandler() {}
 
@@ -93,8 +87,8 @@ bool QtAliceVisionImageIOHandler::read(QImage* image)
     oiio::ImageSpec inSpec = aliceVision::image::readImageSpec(path);
     float pixelAspectRatio = inSpec.get_float_attribute("PixelAspectRatio", 1.0f);
 
-    qDebug() << "[QtAliceVisionImageIO] width:" << inSpec.width << ", height:" << inSpec.height
-             << ", nchannels:" << inSpec.nchannels << ", pixelAspectRatio:" << pixelAspectRatio;
+    qDebug() << "[QtAliceVisionImageIO] width:" << inSpec.width << ", height:" << inSpec.height << ", nchannels:" << inSpec.nchannels
+             << ", pixelAspectRatio:" << pixelAspectRatio;
 
     qDebug() << "[QtAliceVisionImageIO] create output QImage";
     QImage result(inSpec.width, inSpec.height, QImage::Format_RGB32);
@@ -210,12 +204,8 @@ void QtAliceVisionImageIOHandler::setOption(ImageOption option, const QVariant& 
     if (option == ScaledSize && value.isValid())
     {
         _scaledSize = value.value<QSize>();
-        qDebug() << "[QtAliceVisionImageIO] setOption scaledSize: " << _scaledSize.width() << "x"
-                 << _scaledSize.height();
+        qDebug() << "[QtAliceVisionImageIO] setOption scaledSize: " << _scaledSize.width() << "x" << _scaledSize.height();
     }
 }
 
-QByteArray QtAliceVisionImageIOHandler::name() const
-{
-    return "AliceVisionImageIO";
-}
+QByteArray QtAliceVisionImageIOHandler::name() const { return "AliceVisionImageIO"; }

--- a/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.hpp
+++ b/src/qtAliceVisionImageIO/QtAliceVisionImageIOHandler.hpp
@@ -5,7 +5,7 @@
 
 class QtAliceVisionImageIOHandler : public QImageIOHandler
 {
-public:
+  public:
     QtAliceVisionImageIOHandler();
     ~QtAliceVisionImageIOHandler();
 

--- a/src/qtAliceVisionImageIO/plugin.hpp
+++ b/src/qtAliceVisionImageIO/plugin.hpp
@@ -5,14 +5,14 @@
 
 class QtAliceVisionImageIOPlugin : public QImageIOPlugin
 {
-public:
+  public:
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QImageIOHandlerFactoryInterface" FILE "QtAliceVisionImageIOPlugin.json")
 
-public:
+  public:
     QStringList _supportedExtensions;
 
-public:
+  public:
     QtAliceVisionImageIOPlugin();
     ~QtAliceVisionImageIOPlugin();
 


### PR DESCRIPTION
This PR updates the .clang-format file with a greater set of rules and uses it to reformat the entire repository. A .git-blame-ignore-revs file is also added and initialized with the reformatting commit from this PR as well as some previous commits dedicated to reformatting and cleaning-up.