### PR TITLE
[qmlSfmData] Filter `CameraLocatorEntity` objects based on their resection IDs

### DIFF
--- a/src/qmlSfmData/CameraLocatorEntity.cpp
+++ b/src/qmlSfmData/CameraLocatorEntity.cpp
@@ -12,9 +12,11 @@
 
 namespace sfmdataentity {
 
-CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT& viewId, float hfov, float vfov, Qt3DCore::QNode* parent)
+CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT& viewId, const aliceVision::IndexT& resectionId,
+                                         float hfov, float vfov, Qt3DCore::QNode* parent)
   : Qt3DCore::QEntity(parent),
-    _viewId(viewId)
+    _viewId(viewId),
+    _resectionId(resectionId)
 {
     _transform = new Qt3DCore::QTransform;
     addComponent(_transform);

--- a/src/qmlSfmData/CameraLocatorEntity.hpp
+++ b/src/qmlSfmData/CameraLocatorEntity.hpp
@@ -12,18 +12,24 @@ class CameraLocatorEntity : public Qt3DCore::QEntity
     Q_OBJECT
 
     Q_PROPERTY(quint32 viewId MEMBER _viewId NOTIFY viewIdChanged)
+    Q_PROPERTY(quint32 resectionId MEMBER _resectionId NOTIFY resectionIdChanged)
 
   public:
-    explicit CameraLocatorEntity(const aliceVision::IndexT& viewId, float hfov, float vfov, Qt3DCore::QNode* = nullptr);
+    explicit CameraLocatorEntity(const aliceVision::IndexT& viewId, const aliceVision::IndexT& resectionId,
+                                 float hfov, float vfov, Qt3DCore::QNode* = nullptr);
     ~CameraLocatorEntity() override = default;
 
     void setTransform(const Eigen::Matrix4d&);
 
+    aliceVision::IndexT resectionId() const { return _resectionId; }
+
     Q_SIGNAL void viewIdChanged();
+    Q_SIGNAL void resectionIdChanged();
 
   private:
     Qt3DCore::QTransform* _transform;
     aliceVision::IndexT _viewId;
+    aliceVision::IndexT _resectionId;
 };
 
 }  // namespace sfmdataentity

--- a/src/qmlSfmData/SfmDataEntity.cpp
+++ b/src/qmlSfmData/SfmDataEntity.cpp
@@ -198,7 +198,7 @@ void SfmDataEntity::onIOThreadFinished()
             double hfov = intrinsic->getHorizontalFov();
             double vfov = intrinsic->getVerticalFov();
 
-            CameraLocatorEntity* entity = new CameraLocatorEntity(pv.first, hfov, vfov, root);
+            CameraLocatorEntity* entity = new CameraLocatorEntity(pv.first, pv.second->getResectionId(), hfov, vfov, root);
             entity->addComponent(_cameraMaterial);
             entity->setTransform(sfmData.getPoses().at(pv.second->getPoseId()).getTransform().getHomogeneous());
             entity->setObjectName(std::to_string(pv.first).c_str());

--- a/src/qmlSfmData/SfmDataEntity.hpp
+++ b/src/qmlSfmData/SfmDataEntity.hpp
@@ -10,6 +10,8 @@
 
 #include <iostream>
 
+#include <aliceVision/types.hpp>
+
 namespace sfmdataentity {
 class PointCloudEntity;
 class CameraLocatorEntity;
@@ -24,6 +26,7 @@ class SfmDataEntity : public Qt3DCore::QEntity
     Q_PROPERTY(float locatorScale READ locatorScale WRITE setLocatorScale NOTIFY locatorScaleChanged)
     Q_PROPERTY(QQmlListProperty<sfmdataentity::CameraLocatorEntity> cameras READ cameras NOTIFY camerasChanged)
     Q_PROPERTY(QQmlListProperty<sfmdataentity::PointCloudEntity> pointClouds READ pointClouds NOTIFY pointCloudsChanged)
+    Q_PROPERTY(quint32 resectionId READ resectionId WRITE setResectionId NOTIFY resectionIdChanged)
 
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
 
@@ -44,9 +47,11 @@ class SfmDataEntity : public Qt3DCore::QEntity
     Q_SLOT const QUrl& source() const { return _source; }
     Q_SLOT float pointSize() const { return _pointSize; }
     Q_SLOT float locatorScale() const { return _locatorScale; }
+    Q_SLOT aliceVision::IndexT resectionId() const { return _resectionId; }
     Q_SLOT void setSource(const QUrl& source);
     Q_SLOT void setPointSize(const float& value);
     Q_SLOT void setLocatorScale(const float& value);
+    Q_SLOT void setResectionId(const aliceVision::IndexT& value);
 
     Status status() const { return _status; }
 
@@ -66,6 +71,7 @@ class SfmDataEntity : public Qt3DCore::QEntity
     Q_SIGNAL void objectPicked(Qt3DCore::QTransform* transform);
     Q_SIGNAL void statusChanged(Status status);
     Q_SIGNAL void skipHiddenChanged();
+    Q_SIGNAL void resectionIdChanged();
 
   protected:
     /// Scale child locators
@@ -88,6 +94,7 @@ class SfmDataEntity : public Qt3DCore::QEntity
     bool _skipHidden = false;
     float _pointSize = 0.5f;
     float _locatorScale = 1.0f;
+    aliceVision::IndexT _resectionId = 0;
     Qt3DRender::QParameter* _pointSizeParameter;
     Qt3DRender::QMaterial* _cloudMaterial;
     Qt3DRender::QMaterial* _cameraMaterial;


### PR DESCRIPTION
This PR does the following:
1. Create `CameraLocatorEntity` objects with the resection ID they are associated to, and make it accessible;
2. Add a `resectionId` property on which the `CameraLocatorEntity` objects are filtered: if a `CameraLocatorEntity`'s resection ID is higher than the property's value, it is disabled, and thus hidden from the 3D view. On the contrary, if it is lower or equal toi the property's value, it is enabled and displayed in the 3D view.

A couple of C-style casts are also updated to C++ casts. 

This relates to https://github.com/alicevision/Meshroom/pull/2235 and https://github.com/alicevision/AliceVision/pull/1593.