### PR TITLE
[qmlSfmData] Upscale the currently selected camera

### DIFF
--- a/src/qmlSfmData/CameraLocatorEntity.hpp
+++ b/src/qmlSfmData/CameraLocatorEntity.hpp
@@ -21,6 +21,7 @@ class CameraLocatorEntity : public Qt3DCore::QEntity
 
     void setTransform(const Eigen::Matrix4d&);
 
+    aliceVision::IndexT viewId() const { return _viewId; }
     aliceVision::IndexT resectionId() const { return _resectionId; }
 
     Q_SIGNAL void viewIdChanged();

--- a/src/qmlSfmData/CameraLocatorEntity.hpp
+++ b/src/qmlSfmData/CameraLocatorEntity.hpp
@@ -2,7 +2,10 @@
 
 #include <QEntity>
 #include <Qt3DCore/QTransform>
+#include <Qt3DRender/QAttribute>
+
 #include <Eigen/Dense>
+
 #include <aliceVision/types.hpp>
 
 namespace sfmdataentity {
@@ -20,6 +23,8 @@ class CameraLocatorEntity : public Qt3DCore::QEntity
     ~CameraLocatorEntity() override = default;
 
     void setTransform(const Eigen::Matrix4d&);
+    QVector<float> initializeColors(int size, float defaultValue = 1.0f);
+    void updateColors(float red, float green, float blue);
 
     aliceVision::IndexT viewId() const { return _viewId; }
     aliceVision::IndexT resectionId() const { return _resectionId; }
@@ -31,6 +36,8 @@ class CameraLocatorEntity : public Qt3DCore::QEntity
     Qt3DCore::QTransform* _transform;
     aliceVision::IndexT _viewId;
     aliceVision::IndexT _resectionId;
+    Qt3DRender::QAttribute* _colorAttribute;
+    QVector<float> _colors;
 };
 
 }  // namespace sfmdataentity

--- a/src/qmlSfmData/SfmDataEntity.cpp
+++ b/src/qmlSfmData/SfmDataEntity.cpp
@@ -72,10 +72,12 @@ void SfmDataEntity::scaleLocators() const
         {
             if (entity->viewId() == _selectedViewId)
             {
+                entity->updateColors(0.f, 0.f, 1.f);
                 transform->setScale(_locatorScale * 1.5f);
             }
             else
             {
+                entity->updateColors(1.f, 1.f, 1.f);
                 transform->setScale(_locatorScale);
             }
         }
@@ -95,6 +97,7 @@ void SfmDataEntity::setSelectedViewId(const aliceVision::IndexT& viewId)
     {
         if (entity->viewId() == _selectedViewId)  // Previously selected camera: the scale must be reset
         {
+            entity->updateColors(1.f, 1.f, 1.f);
             for (auto* transform : entity->findChildren<Qt3DCore::QTransform*>(QString(), Qt::FindDirectChildrenOnly))
             {
                 transform->setScale(_locatorScale);
@@ -103,6 +106,7 @@ void SfmDataEntity::setSelectedViewId(const aliceVision::IndexT& viewId)
         }
         else if (entity->viewId() == viewId)  // Newly selected camera: the scale must be enlarged
         {
+            entity->updateColors(0.f, 0.f, 1.f);
             for (auto* transform : entity->findChildren<Qt3DCore::QTransform*>(QString(), Qt::FindDirectChildrenOnly))
             {
                 transform->setScale(_locatorScale * 1.5f);

--- a/src/qmlSfmData/SfmDataEntity.cpp
+++ b/src/qmlSfmData/SfmDataEntity.cpp
@@ -70,9 +70,54 @@ void SfmDataEntity::scaleLocators() const
     {
         for (auto* transform : entity->findChildren<Qt3DCore::QTransform*>(QString(), Qt::FindDirectChildrenOnly))
         {
-            transform->setScale(_locatorScale);
+            if (entity->viewId() == _selectedViewId)
+            {
+                transform->setScale(_locatorScale * 1.5f);
+            }
+            else
+            {
+                transform->setScale(_locatorScale);
+            }
         }
     }
+}
+
+void SfmDataEntity::setSelectedViewId(const aliceVision::IndexT& viewId)
+{
+    if (_selectedViewId == viewId)
+    {
+        return;
+    }
+
+    bool previousReset = _selectedViewId == 0 ? true : false;
+    bool newUpdated = false;
+    for (auto* entity : _cameras)
+    {
+        if (entity->viewId() == _selectedViewId)  // Previously selected camera: the scale must be reset
+        {
+            for (auto* transform : entity->findChildren<Qt3DCore::QTransform*>(QString(), Qt::FindDirectChildrenOnly))
+            {
+                transform->setScale(_locatorScale);
+            }
+            previousReset = true;
+        }
+        else if (entity->viewId() == viewId)  // Newly selected camera: the scale must be enlarged
+        {
+            for (auto* transform : entity->findChildren<Qt3DCore::QTransform*>(QString(), Qt::FindDirectChildrenOnly))
+            {
+                transform->setScale(_locatorScale * 1.5f);
+            }
+            newUpdated = true;
+        }
+
+        if (previousReset && newUpdated)
+        {
+            break;
+        }
+    }
+    _selectedViewId = viewId;
+
+    Q_EMIT selectedViewIdChanged();
 }
 
 void SfmDataEntity::setResectionId(const aliceVision::IndexT& value)

--- a/src/qmlSfmData/SfmDataEntity.hpp
+++ b/src/qmlSfmData/SfmDataEntity.hpp
@@ -26,6 +26,7 @@ class SfmDataEntity : public Qt3DCore::QEntity
     Q_PROPERTY(float locatorScale READ locatorScale WRITE setLocatorScale NOTIFY locatorScaleChanged)
     Q_PROPERTY(QQmlListProperty<sfmdataentity::CameraLocatorEntity> cameras READ cameras NOTIFY camerasChanged)
     Q_PROPERTY(QQmlListProperty<sfmdataentity::PointCloudEntity> pointClouds READ pointClouds NOTIFY pointCloudsChanged)
+    Q_PROPERTY(quint32 selectedViewId READ selectedViewId WRITE setSelectedViewId NOTIFY selectedViewIdChanged)
     Q_PROPERTY(quint32 resectionId READ resectionId WRITE setResectionId NOTIFY resectionIdChanged)
 
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
@@ -47,10 +48,12 @@ class SfmDataEntity : public Qt3DCore::QEntity
     Q_SLOT const QUrl& source() const { return _source; }
     Q_SLOT float pointSize() const { return _pointSize; }
     Q_SLOT float locatorScale() const { return _locatorScale; }
+    Q_SLOT aliceVision::IndexT selectedViewId() const { return _selectedViewId; }
     Q_SLOT aliceVision::IndexT resectionId() const { return _resectionId; }
     Q_SLOT void setSource(const QUrl& source);
     Q_SLOT void setPointSize(const float& value);
     Q_SLOT void setLocatorScale(const float& value);
+    Q_SLOT void setSelectedViewId(const aliceVision::IndexT& viewId);
     Q_SLOT void setResectionId(const aliceVision::IndexT& value);
 
     Status status() const { return _status; }
@@ -71,6 +74,7 @@ class SfmDataEntity : public Qt3DCore::QEntity
     Q_SIGNAL void objectPicked(Qt3DCore::QTransform* transform);
     Q_SIGNAL void statusChanged(Status status);
     Q_SIGNAL void skipHiddenChanged();
+    Q_SIGNAL void selectedViewIdChanged();
     Q_SIGNAL void resectionIdChanged();
 
   protected:
@@ -94,6 +98,7 @@ class SfmDataEntity : public Qt3DCore::QEntity
     bool _skipHidden = false;
     float _pointSize = 0.5f;
     float _locatorScale = 1.0f;
+    aliceVision::IndexT _selectedViewId = 0;
     aliceVision::IndexT _resectionId = 0;
     Qt3DRender::QParameter* _pointSizeParameter;
     Qt3DRender::QMaterial* _cloudMaterial;


### PR DESCRIPTION
This PR adds a getter for the `viewId` member of the `CameraLocatorEntity` object and uses it to determine the camera that is currently selected. 

That specific camera is upscaled with a factor of 1.5 in order to better stand out and the color of its gizmo is set to blue. Prior to this PR, the currently selected camera was only highlighted by having its object picker's color set to blue. For photogrammetry use cases, this was enough to identify it easily as the cameras are generally spread around. For camera tracking use cases, this was more difficult as the cameras are very closely following each other.

As soon as the camera is not selected anymore, it is rescaled normally and the gizmo's color is set to white again. The upscale is also correctly applied when the global scale for all the cameras is updated. 

The information about the currently selected camera is obtained from the QML side through https://github.com/alicevision/Meshroom/pull/2237.