### PR TITLE
Align scale of camera selector with camera

### DIFF
--- a/src/qmlSfmData/SfmDataEntity.cpp
+++ b/src/qmlSfmData/SfmDataEntity.cpp
@@ -65,9 +65,10 @@ void SfmDataEntity::setLocatorScale(const float& value)
 
 void SfmDataEntity::scaleLocators() const
 {
+    
     for (auto* entity : _cameras)
     {
-        for (auto* transform : entity->findChildren<Qt3DCore::QTransform*>())
+        for (auto* transform : entity->findChildren<Qt3DCore::QTransform*>(QString(), Qt::FindDirectChildrenOnly))
         {
             transform->setScale(_locatorScale);
         }


### PR DESCRIPTION
This fixes a scale issue with the camera's `ObjectPicker` in Meshroom where the scale changes were not proportional to the value that was set through the slider. 