### PR TITLE
Upgrade tracks to allow more advanced storage and reduce indirections

### DIFF
--- a/src/qtAliceVision/FeaturesViewer.cpp
+++ b/src/qtAliceVision/FeaturesViewer.cpp
@@ -729,13 +729,15 @@ void FeaturesViewer::updateReconstruction()
             trackData.averageScale = 0.f;
             trackData.nbReconstructed = 0;
 
-            for (const auto& [viewId, featureId] : track.featPerView)
+            for (const auto& [viewId, trackItem] : track.featPerView)
             {
                 const auto featureDatasIt = _mreconstruction.featureDatasPerView.find(static_cast<aliceVision::IndexT>(viewId));
                 if (featureDatasIt == _mreconstruction.featureDatasPerView.end())
                 {
                     continue;
                 }
+
+                size_t featureId = trackItem.featureId;
 
                 auto& featureDatas = featureDatasIt->second;
                 if (featureId >= featureDatas.size())


### PR DESCRIPTION
tracks was a list of featureIds per view and now a structure per view.

For the moment this structure only contains the featureId to make sure we don't do regression.

Adapt to https://github.com/alicevision/AliceVision/pull/1594