### PR TITLE
[qtAliceVision] FloatImageViewer: Set the loading status to "error" when an image fails to be loaded

### DIFF
--- a/src/qtAliceVision/FloatImageViewer.hpp
+++ b/src/qtAliceVision/FloatImageViewer.hpp
@@ -41,7 +41,7 @@ class FloatImageViewer : public QQuickItem
 
     Q_PROPERTY(QSize sourceSize READ sourceSize NOTIFY sourceSizeChanged)
 
-    Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+    Q_PROPERTY(EStatus status READ status NOTIFY statusChanged)
 
     Q_PROPERTY(bool clearBeforeLoad MEMBER _clearBeforeLoad NOTIFY clearBeforeLoadChanged)
 
@@ -66,6 +66,20 @@ class FloatImageViewer : public QQuickItem
   public:
     explicit FloatImageViewer(QQuickItem* parent = nullptr);
     ~FloatImageViewer() override;
+
+    enum class EStatus : quint8
+    {
+        NONE,              // nothing is happening, no error has been detected
+        LOADING,           // an image is being loaded
+        OUTDATED_LOADING,  // an image was already loading during the previous reload()
+        MISSING_FILE,      // the file to load is missing
+        ERROR              // generic error
+    };
+    Q_ENUM(EStatus)
+
+    EStatus status() const { return _status; }
+
+    void setStatus(EStatus status);
 
     bool loading() const { return _loading; }
 
@@ -103,7 +117,7 @@ class FloatImageViewer : public QQuickItem
 
     // Q_SIGNALS
     Q_SIGNAL void sourceChanged();
-    Q_SIGNAL void loadingChanged();
+    Q_SIGNAL void statusChanged();
     Q_SIGNAL void clearBeforeLoadChanged();
     Q_SIGNAL void gammaChanged();
     Q_SIGNAL void gainChanged();
@@ -147,6 +161,7 @@ class FloatImageViewer : public QQuickItem
     float _gamma = 1.f;
     float _gain = 1.f;
 
+    EStatus _status = EStatus::NONE;
     bool _loading = false;
     bool _outdated = false;
     bool _clearBeforeLoad = true;

--- a/src/qtAliceVision/ImageServer.hpp
+++ b/src/qtAliceVision/ImageServer.hpp
@@ -13,6 +13,13 @@
 namespace qtAliceVision {
 namespace imgserve {
 
+enum LoadingStatus
+{
+    SUCCESSFUL,
+    MISSING_FILE,
+    ERROR
+};
+
 /**
  * @brief Utility structure to encapsulate an image loading request.
  */
@@ -33,6 +40,8 @@ struct ResponseData
     QSize dim;
 
     QVariantMap metadata;
+
+    LoadingStatus error = SUCCESSFUL;
 };
 
 /**

--- a/src/qtAliceVision/SingleImageLoader.cpp
+++ b/src/qtAliceVision/SingleImageLoader.cpp
@@ -5,6 +5,8 @@
 #include <stdexcept>
 #include <iostream>
 
+#include <boost/filesystem.hpp>
+
 namespace qtAliceVision {
 namespace imgserve {
 
@@ -90,6 +92,16 @@ void SingleImageLoadingIORunnable::run()
     }
     catch (const std::runtime_error& e)
     {
+        // std::runtime_error at this point is a "can't find/open image" error
+        if (!boost::filesystem::exists(_reqData.path))  // "can't find image" case
+        {
+            response.error = MISSING_FILE;
+        }
+        else  // "can't open image" case
+        {
+            response.error = ERROR;
+        }
+
         // Log error message
         std::cerr << e.what() << std::endl;
     }


### PR DESCRIPTION
This PR does the following:
1. Add an enum `error` member to the `ResponseData` structure that is meant to be set whenever an error occurs while attempting to load an image. "Missing file" errors are distinguished from generic errors (and in particular, from "Can't open file" errors).
2. Add an enum that reflects the global status of the FloatImageViewer. It describes accurately whether the viewer has encountered an error (with several types of errors, which can be extended as needed), if an image is being loaded, or if nothing is happening (and no error has been detected). The global status uses the `loading` status to determine its current state. As a consequence, the `loading` status is not exposed anymore to the QML side.
The global status can currently be set with the following values:
    - `NONE`: nothing is happening and the last operations have been successful;
    - `LOADING`: an image is being loaded (the `loading` status is set to true);
    - `OUTDATED_LOADING`: an image was already loading during the previous reload() operation (the `loading` status is still set to true but something wrong might be happening somewhere);
    - `MISSING_FILE`: the file to load is missing;
    - `ERROR`: an unspecified error occurred.

This relates to the following Meshroom pull request: https://github.com/alicevision/Meshroom/pull/2250.