### PR TITLE
[qmlSfmData] Only disable cameras in resection groups if the option has been enabled

### DIFF
--- a/src/qmlSfmData/CameraLocatorEntity.cpp
+++ b/src/qmlSfmData/CameraLocatorEntity.cpp
@@ -56,8 +56,8 @@ CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT& viewId, cons
     tr.y() = sin(vfov / 2.0f);
     tr.z() = cos(vfov / 2.0f);
 
-    const float vslice = vfov / double(subdiv);
-    const float hslice = hfov / double(subdiv);
+    const float vslice = vfov / static_cast<double>(subdiv);
+    const float hslice = hfov / static_cast<double>(subdiv);
 
     Eigen::Vector3d vZ = - Eigen::Vector3d::UnitZ() * radius;
 

--- a/src/qmlSfmData/SfmDataEntity.cpp
+++ b/src/qmlSfmData/SfmDataEntity.cpp
@@ -134,7 +134,7 @@ void SfmDataEntity::setResectionId(const aliceVision::IndexT& value)
     _resectionId = value;
     for (auto* entity : _cameras)
     {
-        if (entity->resectionId() > _resectionId)
+        if (entity->resectionId() > _resectionId && _displayResections)
         {
             entity->setEnabled(false);
         }
@@ -145,6 +145,21 @@ void SfmDataEntity::setResectionId(const aliceVision::IndexT& value)
     }
 
     Q_EMIT resectionIdChanged();
+}
+
+void SfmDataEntity::setDisplayResections(const bool value)
+{
+    if (_displayResections == value)
+    {
+        return;
+    }
+
+    _displayResections = value;
+    // Re-enable all cameras both when the display of the resections is enabled and when it is disabled
+    for (auto* entity : _cameras)
+    {
+        entity->setEnabled(true);
+    }
 }
 
 void SfmDataEntity::createMaterials()
@@ -274,7 +289,7 @@ void SfmDataEntity::onIOThreadFinished()
             entity->addComponent(_cameraMaterial);
             entity->setTransform(sfmData.getPoses().at(pv.second->getPoseId()).getTransform().getHomogeneous());
             entity->setObjectName(std::to_string(pv.first).c_str());
-            if (entity->resectionId() > _resectionId)
+            if (entity->resectionId() > _resectionId && _displayResections)
             {
                 entity->setEnabled(false);
             }

--- a/src/qmlSfmData/SfmDataEntity.hpp
+++ b/src/qmlSfmData/SfmDataEntity.hpp
@@ -28,6 +28,7 @@ class SfmDataEntity : public Qt3DCore::QEntity
     Q_PROPERTY(QQmlListProperty<sfmdataentity::PointCloudEntity> pointClouds READ pointClouds NOTIFY pointCloudsChanged)
     Q_PROPERTY(quint32 selectedViewId READ selectedViewId WRITE setSelectedViewId NOTIFY selectedViewIdChanged)
     Q_PROPERTY(quint32 resectionId READ resectionId WRITE setResectionId NOTIFY resectionIdChanged)
+    Q_PROPERTY(bool displayResections READ displayResections WRITE setDisplayResections NOTIFY displayResectionsChanged)
 
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
 
@@ -50,11 +51,13 @@ class SfmDataEntity : public Qt3DCore::QEntity
     Q_SLOT float locatorScale() const { return _locatorScale; }
     Q_SLOT aliceVision::IndexT selectedViewId() const { return _selectedViewId; }
     Q_SLOT aliceVision::IndexT resectionId() const { return _resectionId; }
+    Q_SLOT bool displayResections() const { return _displayResections; }
     Q_SLOT void setSource(const QUrl& source);
     Q_SLOT void setPointSize(const float& value);
     Q_SLOT void setLocatorScale(const float& value);
     Q_SLOT void setSelectedViewId(const aliceVision::IndexT& viewId);
     Q_SLOT void setResectionId(const aliceVision::IndexT& value);
+    Q_SLOT void setDisplayResections(const bool value);
 
     Status status() const { return _status; }
 
@@ -76,6 +79,7 @@ class SfmDataEntity : public Qt3DCore::QEntity
     Q_SIGNAL void skipHiddenChanged();
     Q_SIGNAL void selectedViewIdChanged();
     Q_SIGNAL void resectionIdChanged();
+    Q_SIGNAL void displayResectionsChanged();
 
   protected:
     /// Scale child locators
@@ -100,6 +104,7 @@ class SfmDataEntity : public Qt3DCore::QEntity
     float _locatorScale = 1.0f;
     aliceVision::IndexT _selectedViewId = 0;
     aliceVision::IndexT _resectionId = 0;
+    bool _displayResections = false;
     Qt3DRender::QParameter* _pointSizeParameter;
     Qt3DRender::QMaterial* _cloudMaterial;
     Qt3DRender::QMaterial* _cameraMaterial;


### PR DESCRIPTION
Fixes issue introduced with #51: when the resection ID slider was disabled on the QML side, the current resection ID was still updated on the QtAliceVision side, meaning that `CameraLocatorEntity` objects were sometimes hidden without any action from the user or any warning. 

This would happen for example if several StructureFromMotion outputs with a different number of resection groups were loaded in the 3D viewer at the same time: upon selecting the output with fewer resection groups, the one(s) with more groups would hide all their `CameraLocatorEntity` objects with a resection ID higher than the selected output's without the user's notice.

Whether or not the resection groups are to be displayed is now accounted for. 

Relates to https://github.com/alicevision/Meshroom/pull/2257.