### PR TITLE
Improve robustness in the multi-threading context

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
+# [qtAliceVision] Apply clang-format on modified files
+d0fd33d78af7d73f4c1c5ba0de7a1d49d263f5d0
 # Reformat all plugins with latest clang-format rules
 a1969780d11ba0505b6ec99ddedf80e1917616ab
 # [qmlSfmData] Clean-up: Fix warnings and harmonize code

--- a/src/depthMapEntity/CMakeLists.txt
+++ b/src/depthMapEntity/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(depthMapEntityPlugin
 
 set_target_properties(depthMapEntityPlugin
       PROPERTIES
-      DEBUG_POSTFIX "d"
+      DEBUG_POSTFIX ""
       FOLDER "depthMapEntityPlugin"
       $SOVERSION ${PROJECT_VERSION_MAJOR}
       VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"

--- a/src/qmlSfmData/CMakeLists.txt
+++ b/src/qmlSfmData/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries(sfmDataEntityQmlPlugin
 
 set_target_properties(sfmDataEntityQmlPlugin
     PROPERTIES
-    DEBUG_POSTFIX "d"
+    DEBUG_POSTFIX ""
     FOLDER "sfmDataEntityQmlPlugin"
     SOVERSION ${PROJECT_VERSION_MAJOR}
     VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"

--- a/src/qtAliceVision/CMakeLists.txt
+++ b/src/qtAliceVision/CMakeLists.txt
@@ -77,7 +77,7 @@ target_link_libraries(qtAliceVisionPlugin
 
 set_target_properties(qtAliceVisionPlugin
         PROPERTIES
-        DEBUG_POSTFIX "d"
+        DEBUG_POSTFIX ""
         FOLDER "qtAliceVisionPlugin"
         SOVERSION ${PROJECT_VERSION_MAJOR}
         VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"

--- a/src/qtAliceVision/FeaturesViewer.cpp
+++ b/src/qtAliceVision/FeaturesViewer.cpp
@@ -700,10 +700,18 @@ void FeaturesViewer::updateReconstruction()
 
                 data.hasLandmark = true;
 
-                const auto& view = sfmData.getView(viewId);
-                const auto& pose = sfmData.getPose(view);
+                const auto& view = sfmData.getViewPtr(static_cast<aliceVision::IndexT>(viewId));
+                if(!view)
+                {
+                    continue;
+                }
+                if(!sfmData.isPoseAndIntrinsicDefined(view))
+                {
+                    continue;
+                }
+                const auto& pose = sfmData.getPose(*view);
                 const auto& camTransform = pose.getTransform();
-                const auto& intrinsic = sfmData.getIntrinsicPtr(view.getIntrinsicId());
+                const auto& intrinsic = sfmData.getIntrinsicPtr(view->getIntrinsicId());
                 const aliceVision::Vec2 reprojection = intrinsic->project(camTransform, landmark.X.homogeneous());
                 data.rx = static_cast<float>(reprojection.x());
                 data.ry = static_cast<float>(reprojection.y());
@@ -758,8 +766,10 @@ void FeaturesViewer::updateReconstruction()
                     elt.featureId = static_cast<aliceVision::IndexT>(featureId);
 
                     const auto& sfmData = _msfmdata->rawData();
-                    const auto& view = sfmData.getView(static_cast<aliceVision::IndexT>(viewId));
-                    elt.frameId = view.getFrameId();
+                    if(const auto& view = sfmData.getViewPtr(static_cast<aliceVision::IndexT>(viewId)))
+                    {
+                        elt.frameId = view->getFrameId();
+                    }
 
                     trackData.elements.push_back(elt);
 

--- a/src/qtAliceVision/FeaturesViewer.cpp
+++ b/src/qtAliceVision/FeaturesViewer.cpp
@@ -256,13 +256,13 @@ void FeaturesViewer::updatePaintTracks(const PaintParams& params, QSGNode* node)
 {
     qDebug() << "[QtAliceVision] FeaturesViewer: Update paint " << _describerType << " tracks.";
 
-    bool valid = (_displayTracks && params.haveValidFeatures && params.haveValidTracks && params.haveValidLandmarks &&
-       _msfmdata && _currentViewId != aliceVision::UndefinedIndexT);
-    
+    bool valid = (_displayTracks && params.haveValidFeatures && params.haveValidTracks && params.haveValidLandmarks && _msfmdata &&
+                  _currentViewId != aliceVision::UndefinedIndexT);
+
     aliceVision::IndexT currentFrameId = aliceVision::UndefinedIndexT;
-    if(valid)
+    if (valid)
     {
-        if(_msfmdata->rawData().getViews().count(_currentViewId))
+        if (_msfmdata->rawData().getViews().count(_currentViewId))
         {
             const auto& view = _msfmdata->rawData().getView(_currentViewId);
             currentFrameId = view.getFrameId();
@@ -275,7 +275,7 @@ void FeaturesViewer::updatePaintTracks(const PaintParams& params, QSGNode* node)
         }
     }
 
-    if(!valid)
+    if (!valid)
     {
         painter.clearLayer(node, "trackEndpoints");
         painter.clearLayer(node, "highlightPoints");
@@ -701,12 +701,12 @@ void FeaturesViewer::updateReconstruction()
 
                 data.hasLandmark = true;
 
-                if(!sfmData.getViews().count(viewId))
+                if (!sfmData.getViews().count(viewId))
                 {
                     continue;
                 }
                 const auto& view = sfmData.getView(static_cast<aliceVision::IndexT>(viewId));
-                if(!sfmData.isPoseAndIntrinsicDefined(&view))
+                if (!sfmData.isPoseAndIntrinsicDefined(&view))
                 {
                     continue;
                 }
@@ -767,7 +767,7 @@ void FeaturesViewer::updateReconstruction()
                     elt.featureId = static_cast<aliceVision::IndexT>(featureId);
 
                     const auto& sfmData = _msfmdata->rawData();
-                    if(sfmData.getViews().count(viewId))
+                    if (sfmData.getViews().count(viewId))
                     {
                         const auto& view = sfmData.getView(static_cast<aliceVision::IndexT>(viewId));
                         elt.frameId = view.getFrameId();

--- a/src/qtAliceVision/MViewStats.cpp
+++ b/src/qtAliceVision/MViewStats.cpp
@@ -31,7 +31,11 @@ void MViewStats::fillResidualFullSerie(QXYSeries* residuals)
 
     std::vector<double> residualHistX = _residualHistogramFull.GetXbinsValue();
     std::vector<size_t> residualHistY = _residualHistogramFull.GetHist();
-    assert(residualHistX.size() == residualHistY.size());
+
+    if(residualHistX.size() != residualHistY.size())
+    {
+        throw std::runtime_error("MViewStats::fillResidualFullSerie: residualHistX & residualHistY size mismatch.");
+    }
     QPen pen(Qt::red, 1, Qt::DashLine, Qt::FlatCap, Qt::BevelJoin);
 
     for (std::size_t i = 0; i < residualHistX.size(); ++i)
@@ -63,7 +67,10 @@ void MViewStats::fillResidualViewSerie(QXYSeries* residuals)
 
     std::vector<double> residualHistX = _residualHistogramView.GetXbinsValue();
     std::vector<size_t> residualHistY = _residualHistogramView.GetHist();
-    assert(residualHistX.size() == residualHistY.size());
+    if(residualHistX.size() != residualHistY.size())
+    {
+        throw std::runtime_error("MViewStats::fillResidualViewSerie: residualHistX & residualHistY size mismatch.");
+    }
     QPen pen(Qt::darkBlue, 3, Qt::SolidLine, Qt::FlatCap, Qt::BevelJoin);
 
     for (std::size_t i = 0; i < residualHistX.size(); ++i)
@@ -95,7 +102,10 @@ void MViewStats::fillObservationsLengthsFullSerie(QXYSeries* observationsLengths
 
     std::vector<double> observationsLengthsHistX = _observationsLengthsHistogramFull.GetXbinsValue();
     std::vector<size_t> observationsLengthsHistY = _observationsLengthsHistogramFull.GetHist();
-    assert(observationsLengthsHistX.size() == observationsLengthsHistY.size());
+    if(observationsLengthsHistX.size() != observationsLengthsHistY.size())
+    {
+        throw std::runtime_error("MViewStats::fillObservationsLengthsFullSerie: observationsLengthsHistX & observationsLengthsHistY size mismatch.");
+    }
     QPen pen(Qt::red, 1, Qt::DashLine, Qt::FlatCap, Qt::BevelJoin);
 
     for (std::size_t i = 0; i < observationsLengthsHistX.size(); ++i)
@@ -127,7 +137,10 @@ void MViewStats::fillObservationsLengthsViewSerie(QXYSeries* observationsLengths
 
     std::vector<double> observationsLengthsHistX = _observationsLengthsHistogramView.GetXbinsValue();
     std::vector<size_t> observationsLengthsHistY = _observationsLengthsHistogramView.GetHist();
-    assert(observationsLengthsHistX.size() == observationsLengthsHistY.size());
+    if(observationsLengthsHistX.size() != observationsLengthsHistY.size())
+    {
+        throw std::runtime_error("MViewStats::fillObservationsLengthsViewSerie: observationsLengthsHistX & observationsLengthsHistY size mismatch.");
+    }
     QPen pen(Qt::darkBlue, 3, Qt::SolidLine, Qt::FlatCap, Qt::BevelJoin);
 
     for (std::size_t i = 0; i < observationsLengthsHistX.size(); ++i)
@@ -159,7 +172,10 @@ void MViewStats::fillObservationsScaleFullSerie(QXYSeries* observationsScale)
 
     std::vector<double> observationsScaleHistX = _observationsScaleHistogramFull.GetXbinsValue();
     std::vector<size_t> observationsScaleHistY = _observationsScaleHistogramFull.GetHist();
-    assert(observationsScaleHistX.size() == observationsScaleHistY.size());
+    if(observationsScaleHistX.size() != observationsScaleHistY.size())
+    {
+        throw std::runtime_error("MViewStats::fillObservationsScaleFullSerie: observationsScaleHistX & observationsScaleHistY size mismatch.");
+    }
     QPen pen(Qt::red, 1, Qt::DashLine, Qt::FlatCap, Qt::BevelJoin);
 
     for (std::size_t i = 0; i < observationsScaleHistX.size(); ++i)
@@ -191,7 +207,10 @@ void MViewStats::fillObservationsScaleViewSerie(QXYSeries* observationsScale)
 
     std::vector<double> observationsScaleHistX = _observationsScaleHistogramView.GetXbinsValue();
     std::vector<size_t> observationsScaleHistY = _observationsScaleHistogramView.GetHist();
-    assert(observationsScaleHistX.size() == observationsScaleHistY.size());
+    if(observationsScaleHistX.size() != observationsScaleHistY.size())
+    {
+        throw std::runtime_error("MViewStats::fillObservationsScaleViewSerie: observationsScaleHistX & observationsScaleHistY size mismatch.");
+    }
     QPen pen(Qt::darkBlue, 3, Qt::SolidLine, Qt::FlatCap, Qt::BevelJoin);
 
     for (std::size_t i = 0; i < observationsScaleHistX.size(); ++i)
@@ -243,7 +262,10 @@ void MViewStats::computeViewStats()
                 residualFullHistY[i] = static_cast<size_t>(round(static_cast<double>(residualFullHistY[i]) / nbCameras));
             }
             std::vector<double> residualHistX = _residualHistogramFull.GetXbinsValue();
-            assert(residualHistX.size() == residualFullHistY.size());
+            if(residualHistX.size() != residualFullHistY.size())
+            {
+                throw std::runtime_error("MViewStats::computeViewStats: residualHistX & residualFullHistY size mismatch.");
+            }
             for (std::size_t i = 0; i < residualFullHistY.size(); ++i)
             {
                 _residualMaxAxisX = round(std::max(_residualMaxAxisX, residualHistX[i]));
@@ -256,7 +278,10 @@ void MViewStats::computeViewStats()
             sfm::computeResidualsHistogram(_msfmData->rawData(), residualViewStats, &_residualHistogramView, {_viewId});
             std::vector<size_t>& residualViewHistY = _residualHistogramView.GetHist();
             std::vector<double> residualHistX = _residualHistogramView.GetXbinsValue();
-            assert(residualHistX.size() == residualViewHistY.size());
+            if(residualHistX.size() != residualViewHistY.size())
+            {
+                throw std::runtime_error("MViewStats::computeViewStats: residualHistX & residualViewHistY size mismatch.");
+            }
 
             for (std::size_t i = 0; i < residualViewHistY.size(); ++i)
             {
@@ -286,7 +311,10 @@ void MViewStats::computeViewStats()
                 observationsLengthsFullHistY[i] = static_cast<size_t>(round(static_cast<double>(observationsLengthsFullHistY[i]) / nbCameras));
             }
             std::vector<double> observationsLengthsHistX = _observationsLengthsHistogramFull.GetXbinsValue();
-            assert(observationsLengthsHistX.size() == observationsLengthsFullHistY.size());
+            if(observationsLengthsHistX.size() != observationsLengthsFullHistY.size())
+            {
+                throw std::runtime_error("MViewStats::computeViewStats: observationsLengthsHistX & observationsLengthsFullHistY size mismatch.");
+            }
             for (std::size_t i = 0; i < observationsLengthsFullHistY.size(); ++i)
             {
                 _observationsLengthsMaxAxisX = round(std::max(_observationsLengthsMaxAxisX, observationsLengthsHistX[i]));
@@ -300,7 +328,10 @@ void MViewStats::computeViewStats()
               _msfmData->rawData(), observationsLengthsViewStats, _nbObservations, &_observationsLengthsHistogramView, {_viewId});
             std::vector<size_t> observationsLengthsViewHistY = _observationsLengthsHistogramView.GetHist();
             std::vector<double> observationsLengthsHistX = _observationsLengthsHistogramView.GetXbinsValue();
-            assert(observationsLengthsHistX.size() == observationsLengthsViewHistY.size());
+            if(observationsLengthsHistX.size() != observationsLengthsViewHistY.size())
+            {
+                throw std::runtime_error("MViewStats::computeViewStats: observationsLengthsHistX & observationsLengthsViewHistY size mismatch.");
+            }
 
             for (std::size_t i = 0; i < observationsLengthsViewHistY.size(); ++i)
             {
@@ -325,13 +356,23 @@ void MViewStats::computeViewStats()
             observationsScaleFullHistY[i] = static_cast<std::size_t>(std::round(static_cast<double>(observationsScaleFullHistY[i]) / nbCameras));
         }
         std::vector<double> observationsScaleHistX = _observationsScaleHistogramFull.GetXbinsValue();
-        assert(observationsScaleHistX.size() == observationsScaleFullHistY.size());
+        if(observationsScaleHistX.size() != observationsScaleFullHistY.size())
+        {
+            std::stringstream s;
+            s << "MViewStats::computeViewStats: "
+              << "observationsScaleHistX (" << observationsScaleHistX.size() << ") & "
+              << "observationsScaleFullHistY (" << observationsScaleFullHistY.size() << ") size mismatch.";
+            throw std::runtime_error(s.str());
+        }
 
-        // histrogram of observations Scale of current view
+        // histogram of observations Scale of current view
         BoxStats<double> observationsScaleViewStats;
         sfm::computeScaleHistogram(_msfmData->rawData(), observationsScaleViewStats, &_observationsScaleHistogramView, {_viewId});
         std::vector<size_t> observationsScaleViewHistY = _observationsScaleHistogramView.GetHist();
-        assert(observationsScaleHistX.size() == observationsScaleViewHistY.size());
+        if(observationsScaleHistX.size() != observationsScaleViewHistY.size())
+        {
+            throw std::runtime_error("MViewStats::computeViewStats: observationsScaleHistX & observationsScaleViewHistY size mismatch.");
+        }
 
         _observationsScaleMaxAxisX = 0.0;
         _observationsScaleMaxAxisY = 0.0;

--- a/src/qtAliceVision/MViewStats.cpp
+++ b/src/qtAliceVision/MViewStats.cpp
@@ -32,7 +32,7 @@ void MViewStats::fillResidualFullSerie(QXYSeries* residuals)
     std::vector<double> residualHistX = _residualHistogramFull.GetXbinsValue();
     std::vector<size_t> residualHistY = _residualHistogramFull.GetHist();
 
-    if(residualHistX.size() != residualHistY.size())
+    if (residualHistX.size() != residualHistY.size())
     {
         throw std::runtime_error("MViewStats::fillResidualFullSerie: residualHistX & residualHistY size mismatch.");
     }
@@ -67,7 +67,7 @@ void MViewStats::fillResidualViewSerie(QXYSeries* residuals)
 
     std::vector<double> residualHistX = _residualHistogramView.GetXbinsValue();
     std::vector<size_t> residualHistY = _residualHistogramView.GetHist();
-    if(residualHistX.size() != residualHistY.size())
+    if (residualHistX.size() != residualHistY.size())
     {
         throw std::runtime_error("MViewStats::fillResidualViewSerie: residualHistX & residualHistY size mismatch.");
     }
@@ -102,7 +102,7 @@ void MViewStats::fillObservationsLengthsFullSerie(QXYSeries* observationsLengths
 
     std::vector<double> observationsLengthsHistX = _observationsLengthsHistogramFull.GetXbinsValue();
     std::vector<size_t> observationsLengthsHistY = _observationsLengthsHistogramFull.GetHist();
-    if(observationsLengthsHistX.size() != observationsLengthsHistY.size())
+    if (observationsLengthsHistX.size() != observationsLengthsHistY.size())
     {
         throw std::runtime_error("MViewStats::fillObservationsLengthsFullSerie: observationsLengthsHistX & observationsLengthsHistY size mismatch.");
     }
@@ -137,7 +137,7 @@ void MViewStats::fillObservationsLengthsViewSerie(QXYSeries* observationsLengths
 
     std::vector<double> observationsLengthsHistX = _observationsLengthsHistogramView.GetXbinsValue();
     std::vector<size_t> observationsLengthsHistY = _observationsLengthsHistogramView.GetHist();
-    if(observationsLengthsHistX.size() != observationsLengthsHistY.size())
+    if (observationsLengthsHistX.size() != observationsLengthsHistY.size())
     {
         throw std::runtime_error("MViewStats::fillObservationsLengthsViewSerie: observationsLengthsHistX & observationsLengthsHistY size mismatch.");
     }
@@ -172,7 +172,7 @@ void MViewStats::fillObservationsScaleFullSerie(QXYSeries* observationsScale)
 
     std::vector<double> observationsScaleHistX = _observationsScaleHistogramFull.GetXbinsValue();
     std::vector<size_t> observationsScaleHistY = _observationsScaleHistogramFull.GetHist();
-    if(observationsScaleHistX.size() != observationsScaleHistY.size())
+    if (observationsScaleHistX.size() != observationsScaleHistY.size())
     {
         throw std::runtime_error("MViewStats::fillObservationsScaleFullSerie: observationsScaleHistX & observationsScaleHistY size mismatch.");
     }
@@ -207,7 +207,7 @@ void MViewStats::fillObservationsScaleViewSerie(QXYSeries* observationsScale)
 
     std::vector<double> observationsScaleHistX = _observationsScaleHistogramView.GetXbinsValue();
     std::vector<size_t> observationsScaleHistY = _observationsScaleHistogramView.GetHist();
-    if(observationsScaleHistX.size() != observationsScaleHistY.size())
+    if (observationsScaleHistX.size() != observationsScaleHistY.size())
     {
         throw std::runtime_error("MViewStats::fillObservationsScaleViewSerie: observationsScaleHistX & observationsScaleHistY size mismatch.");
     }
@@ -262,7 +262,7 @@ void MViewStats::computeViewStats()
                 residualFullHistY[i] = static_cast<size_t>(round(static_cast<double>(residualFullHistY[i]) / nbCameras));
             }
             std::vector<double> residualHistX = _residualHistogramFull.GetXbinsValue();
-            
+
             for (std::size_t i = 0; i < residualHistX.size(); ++i)
             {
                 _residualMaxAxisX = round(std::max(_residualMaxAxisX, residualHistX[i]));

--- a/src/qtAliceVision/MViewStats.cpp
+++ b/src/qtAliceVision/MViewStats.cpp
@@ -262,13 +262,13 @@ void MViewStats::computeViewStats()
                 residualFullHistY[i] = static_cast<size_t>(round(static_cast<double>(residualFullHistY[i]) / nbCameras));
             }
             std::vector<double> residualHistX = _residualHistogramFull.GetXbinsValue();
-            if(residualHistX.size() != residualFullHistY.size())
+            
+            for (std::size_t i = 0; i < residualHistX.size(); ++i)
             {
-                throw std::runtime_error("MViewStats::computeViewStats: residualHistX & residualFullHistY size mismatch.");
+                _residualMaxAxisX = round(std::max(_residualMaxAxisX, residualHistX[i]));
             }
             for (std::size_t i = 0; i < residualFullHistY.size(); ++i)
             {
-                _residualMaxAxisX = round(std::max(_residualMaxAxisX, residualHistX[i]));
                 _residualMaxAxisY = round(std::max(_residualMaxAxisY, double(residualFullHistY[i])));
             }
         }
@@ -278,14 +278,13 @@ void MViewStats::computeViewStats()
             sfm::computeResidualsHistogram(_msfmData->rawData(), residualViewStats, &_residualHistogramView, {_viewId});
             std::vector<size_t>& residualViewHistY = _residualHistogramView.GetHist();
             std::vector<double> residualHistX = _residualHistogramView.GetXbinsValue();
-            if(residualHistX.size() != residualViewHistY.size())
-            {
-                throw std::runtime_error("MViewStats::computeViewStats: residualHistX & residualViewHistY size mismatch.");
-            }
 
-            for (std::size_t i = 0; i < residualViewHistY.size(); ++i)
+            for (std::size_t i = 0; i < residualHistX.size(); ++i)
             {
                 _residualMaxAxisX = round(std::max(_residualMaxAxisX, residualHistX[i]));
+            }
+            for (std::size_t i = 0; i < residualViewHistY.size(); ++i)
+            {
                 _residualMaxAxisY = round(std::max(_residualMaxAxisY, double(residualViewHistY[i])));
             }
         }
@@ -302,7 +301,7 @@ void MViewStats::computeViewStats()
             sfm::computeObservationsLengthsHistogram(
               _msfmData->rawData(), observationsLengthsFullStats, _nbObservations, &_observationsLengthsHistogramFull);
 
-            double nbCameras = double(_msfmData->nbCameras());
+            const double nbCameras = double(_msfmData->nbCameras());
             std::vector<size_t>& observationsLengthsFullHistY = _observationsLengthsHistogramFull.GetHist();
 
             // normalize the histogram to get the average number of observations
@@ -311,13 +310,13 @@ void MViewStats::computeViewStats()
                 observationsLengthsFullHistY[i] = static_cast<size_t>(round(static_cast<double>(observationsLengthsFullHistY[i]) / nbCameras));
             }
             std::vector<double> observationsLengthsHistX = _observationsLengthsHistogramFull.GetXbinsValue();
-            if(observationsLengthsHistX.size() != observationsLengthsFullHistY.size())
+
+            for (std::size_t i = 0; i < observationsLengthsHistX.size(); ++i)
             {
-                throw std::runtime_error("MViewStats::computeViewStats: observationsLengthsHistX & observationsLengthsFullHistY size mismatch.");
+                _observationsLengthsMaxAxisX = round(std::max(_observationsLengthsMaxAxisX, observationsLengthsHistX[i]));
             }
             for (std::size_t i = 0; i < observationsLengthsFullHistY.size(); ++i)
             {
-                _observationsLengthsMaxAxisX = round(std::max(_observationsLengthsMaxAxisX, observationsLengthsHistX[i]));
                 _observationsLengthsMaxAxisY = round(std::max(_observationsLengthsMaxAxisY, double(observationsLengthsFullHistY[i])));
             }
         }
@@ -326,16 +325,15 @@ void MViewStats::computeViewStats()
             BoxStats<double> observationsLengthsViewStats;
             sfm::computeObservationsLengthsHistogram(
               _msfmData->rawData(), observationsLengthsViewStats, _nbObservations, &_observationsLengthsHistogramView, {_viewId});
-            std::vector<size_t> observationsLengthsViewHistY = _observationsLengthsHistogramView.GetHist();
-            std::vector<double> observationsLengthsHistX = _observationsLengthsHistogramView.GetXbinsValue();
-            if(observationsLengthsHistX.size() != observationsLengthsViewHistY.size())
-            {
-                throw std::runtime_error("MViewStats::computeViewStats: observationsLengthsHistX & observationsLengthsViewHistY size mismatch.");
-            }
+            const std::vector<size_t> observationsLengthsViewHistY = _observationsLengthsHistogramView.GetHist();
+            const std::vector<double> observationsLengthsHistX = _observationsLengthsHistogramView.GetXbinsValue();
 
-            for (std::size_t i = 0; i < observationsLengthsViewHistY.size(); ++i)
+            for (std::size_t i = 0; i < observationsLengthsHistX.size(); ++i)
             {
                 _observationsLengthsMaxAxisX = round(std::max(_observationsLengthsMaxAxisX, observationsLengthsHistX[i]));
+            }
+            for (std::size_t i = 0; i < observationsLengthsViewHistY.size(); ++i)
+            {
                 _observationsLengthsMaxAxisY = round(std::max(_observationsLengthsMaxAxisY, double(observationsLengthsViewHistY[i])));
             }
         }
@@ -347,7 +345,7 @@ void MViewStats::computeViewStats()
         BoxStats<double> observationsScaleFullStats;
         sfm::computeScaleHistogram(_msfmData->rawData(), observationsScaleFullStats, &_observationsScaleHistogramFull);
 
-        double nbCameras = double(_msfmData->nbCameras());
+        const double nbCameras = double(_msfmData->nbCameras());
 
         // normalize the histogram to get the average number of observations
         std::vector<size_t>& observationsScaleFullHistY = _observationsScaleHistogramFull.GetHist();
@@ -356,23 +354,11 @@ void MViewStats::computeViewStats()
             observationsScaleFullHistY[i] = static_cast<std::size_t>(std::round(static_cast<double>(observationsScaleFullHistY[i]) / nbCameras));
         }
         std::vector<double> observationsScaleHistX = _observationsScaleHistogramFull.GetXbinsValue();
-        if(observationsScaleHistX.size() != observationsScaleFullHistY.size())
-        {
-            std::stringstream s;
-            s << "MViewStats::computeViewStats: "
-              << "observationsScaleHistX (" << observationsScaleHistX.size() << ") & "
-              << "observationsScaleFullHistY (" << observationsScaleFullHistY.size() << ") size mismatch.";
-            throw std::runtime_error(s.str());
-        }
 
         // histogram of observations Scale of current view
         BoxStats<double> observationsScaleViewStats;
         sfm::computeScaleHistogram(_msfmData->rawData(), observationsScaleViewStats, &_observationsScaleHistogramView, {_viewId});
-        std::vector<size_t> observationsScaleViewHistY = _observationsScaleHistogramView.GetHist();
-        if(observationsScaleHistX.size() != observationsScaleViewHistY.size())
-        {
-            throw std::runtime_error("MViewStats::computeViewStats: observationsScaleHistX & observationsScaleViewHistY size mismatch.");
-        }
+        const std::vector<size_t> observationsScaleViewHistY = _observationsScaleHistogramView.GetHist();
 
         _observationsScaleMaxAxisX = 0.0;
         _observationsScaleMaxAxisY = 0.0;
@@ -380,6 +366,9 @@ void MViewStats::computeViewStats()
         for (std::size_t i = 0; i < observationsScaleHistX.size(); ++i)
         {
             _observationsScaleMaxAxisX = round(std::max(_observationsScaleMaxAxisX, observationsScaleHistX[i]));
+        }
+        for (std::size_t i = 0; i < observationsScaleFullHistY.size(); ++i)
+        {
             _observationsScaleMaxAxisY = round(std::max(_observationsScaleMaxAxisY, double(observationsScaleFullHistY[i])));
         }
         for (std::size_t i = 0; i < observationsScaleViewHistY.size(); ++i)


### PR DESCRIPTION
User may remove node or input images, change scene, etc while we are updating the UI in another thread.
