### PR TITLE
[qtAliceVision] FloatImageViewer: Correctly set the `LOADING` status

### DIFF
--- a/src/qtAliceVision/FloatImageViewer.cpp
+++ b/src/qtAliceVision/FloatImageViewer.cpp
@@ -158,6 +158,7 @@ void FloatImageViewer::reload()
     else
     {
         setLoading(true);
+        setStatus(EStatus::LOADING);
     }
 
     Q_EMIT cachedFramesChanged();


### PR DESCRIPTION
Fixes an issue introduced by #57 where all the statuses are correctly set except for the `LOADING` status. 

Relates to https://github.com/alicevision/Meshroom/pull/2283.