### PR TITLE
Use camelBack case for calls to the SfMDataIO and Image functions

### DIFF
--- a/src/depthMapEntity/DepthMapEntity.cpp
+++ b/src/depthMapEntity/DepthMapEntity.cpp
@@ -248,7 +248,7 @@ void DepthMapEntity::loadDepthMap()
     oiio::ImageBuf inBuf;
     image::getBufferFromImage(depthMap, inBuf);
 
-    qDebug() << "[DepthMapEntity] Image Size: " << depthMap.Width() << "x" << depthMap.Height();
+    qDebug() << "[DepthMapEntity] Image Size: " << depthMap.width() << "x" << depthMap.height();
 
     oiio::ImageSpec inSpec = image::readImageSpec(depthMapPath);
 
@@ -351,21 +351,21 @@ void DepthMapEntity::loadDepthMap()
         qWarning() << "[DepthMapEntity] Failed to find associated sim map";
     }
 
-    const bool validSimMap = (simMap.Width() == depthMap.Width()) && (simMap.Height() == depthMap.Height());
+    const bool validSimMap = (simMap.width() == depthMap.width()) && (simMap.height() == depthMap.height());
 
     // 3D points position and color (using jetColorMap)
 
     qDebug() << "[DepthMapEntity] Computing positions and colors for point cloud";
 
-    std::vector<int> indexPerPixel(static_cast<std::size_t>(depthMap.Width() * depthMap.Height()), -1);
+    std::vector<int> indexPerPixel(static_cast<std::size_t>(depthMap.width() * depthMap.height()), -1);
     std::vector<Vec3f> positions;
     std::vector<image::RGBfColor> colors;
 
     oiio::ImageBufAlgo::PixelStats stats = oiio::ImageBufAlgo::computePixelStats(inBuf);
 
-    for (int y = 0; y < depthMap.Height(); ++y)
+    for (int y = 0; y < depthMap.height(); ++y)
     {
-        for (int x = 0; x < depthMap.Width(); ++x)
+        for (int x = 0; x < depthMap.width(); ++x)
         {
             float depthValue = depthMap(y, x);
             if (!std::isfinite(depthValue) || depthValue <= 0.f)
@@ -374,7 +374,7 @@ void DepthMapEntity::loadDepthMap()
             Point3d p = CArr + (iCamArr * Point2d(static_cast<double>(x), static_cast<double>(y))).normalize() * depthValue;
             Vec3f position(static_cast<float>(p.x), static_cast<float>(-p.y), static_cast<float>(-p.z));
 
-            indexPerPixel[static_cast<std::size_t>(y * depthMap.Width() + x)] = static_cast<int>(positions.size());
+            indexPerPixel[static_cast<std::size_t>(y * depthMap.width() + x)] = static_cast<int>(positions.size());
             positions.push_back(position);
 
             if (validSimMap)
@@ -402,14 +402,14 @@ void DepthMapEntity::loadDepthMap()
     // vertices buffer
     std::vector<std::size_t> trianglesIndexes;
     trianglesIndexes.reserve(2 * 3 * positions.size());
-    for (int y = 0; y < depthMap.Height() - 1; ++y)
+    for (int y = 0; y < depthMap.height() - 1; ++y)
     {
-        for (int x = 0; x < depthMap.Width() - 1; ++x)
+        for (int x = 0; x < depthMap.width() - 1; ++x)
         {
-            int pixelIndexA = indexPerPixel[static_cast<std::size_t>(y * depthMap.Width() + x)];
-            int pixelIndexB = indexPerPixel[static_cast<std::size_t>((y + 1) * depthMap.Width() + x)];
-            int pixelIndexC = indexPerPixel[static_cast<std::size_t>((y + 1) * depthMap.Width() + x + 1)];
-            int pixelIndexD = indexPerPixel[static_cast<std::size_t>(y * depthMap.Width() + x + 1)];
+            int pixelIndexA = indexPerPixel[static_cast<std::size_t>(y * depthMap.width() + x)];
+            int pixelIndexB = indexPerPixel[static_cast<std::size_t>((y + 1) * depthMap.width() + x)];
+            int pixelIndexC = indexPerPixel[static_cast<std::size_t>((y + 1) * depthMap.width() + x + 1)];
+            int pixelIndexD = indexPerPixel[static_cast<std::size_t>(y * depthMap.width() + x + 1)];
 
             // Cast indices to std::size_t once for readability
             std::size_t sPixelIndexA = static_cast<std::size_t>(pixelIndexA);

--- a/src/qmlSfmData/IOThread.cpp
+++ b/src/qmlSfmData/IOThread.cpp
@@ -19,7 +19,7 @@ void IOThread::run()
     QMutexLocker lock(&_mutex);
     try
     {
-        if (!aliceVision::sfmDataIO::Load(
+        if (!aliceVision::sfmDataIO::load(
               _sfmData,
               _source.toLocalFile().toStdString(),
               aliceVision::sfmDataIO::ESfMData(aliceVision::sfmDataIO::ESfMData::VIEWS | aliceVision::sfmDataIO::ESfMData::INTRINSICS |

--- a/src/qtAliceVision/FloatImageViewer.cpp
+++ b/src/qtAliceVision/FloatImageViewer.cpp
@@ -177,7 +177,7 @@ QVector4D FloatImageViewer::pixelValueAt(int x, int y)
         // qInfo() << "[QtAliceVision] FloatImageViewer::pixelValueAt(" << x << ", " << y << ") => no valid image";
         return QVector4D(0.0, 0.0, 0.0, 0.0);
     }
-    else if (x < 0 || x >= _image->Width() || y < 0 || y >= _image->Height())
+    else if (x < 0 || x >= _image->width() || y < 0 || y >= _image->height())
     {
         // qInfo() << "[QtAliceVision] FloatImageViewer::pixelValueAt(" << x << ", " << y << ") => out of range";
         return QVector4D(0.0, 0.0, 0.0, 0.0);
@@ -306,8 +306,8 @@ QSGNode* FloatImageViewer::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdateP
                 const aliceVision::Vec3 fisheyeCircleParams(
                   intrinsicEquidistant->getCircleCenterX(), intrinsicEquidistant->getCircleCenterY(), intrinsicEquidistant->getCircleRadius());
 
-                const double width = _image->Width() * pow(2.0, _downscaleLevel);
-                const double height = _image->Height() * pow(2.0, _downscaleLevel);
+                const double width = _image->width() * pow(2.0, _downscaleLevel);
+                const double height = _image->height() * pow(2.0, _downscaleLevel);
                 const double aspectRatio = (width > height) ? width / height : height / width;
 
                 const double radiusInPercentage = (fisheyeCircleParams.z() / ((width > height) ? height : width)) * 2.0;

--- a/src/qtAliceVision/FloatTexture.cpp
+++ b/src/qtAliceVision/FloatTexture.cpp
@@ -22,13 +22,13 @@ FloatTexture::~FloatTexture()
 void FloatTexture::setImage(std::shared_ptr<FloatImage>& image)
 {
     _srcImage = image;
-    _textureSize = {_srcImage->Width(), _srcImage->Height()};
+    _textureSize = {_srcImage->width(), _srcImage->height()};
     _dirty = true;
     _dirtyBindOptions = true;
     _mipmapsGenerated = false;
 }
 
-bool FloatTexture::isValid() const { return _srcImage->Width() != 0 && _srcImage->Height() != 0; }
+bool FloatTexture::isValid() const { return _srcImage->width() != 0 && _srcImage->height() != 0; }
 
 int FloatTexture::textureId() const
 {
@@ -92,13 +92,13 @@ void FloatTexture::bind()
         }
 
         // Downscale the texture to fit inside the max texture limit if it is too big.
-        while (_maxTextureSize != -1 && (_srcImage->Width() > _maxTextureSize || _srcImage->Height() > _maxTextureSize))
+        while (_maxTextureSize != -1 && (_srcImage->width() > _maxTextureSize || _srcImage->height() > _maxTextureSize))
         {
             FloatImage tmp;
-            aliceVision::image::ImageHalfSample(*_srcImage, tmp);
+            aliceVision::image::imageHalfSample(*_srcImage, tmp);
             *_srcImage = std::move(tmp);
         }
-        _textureSize = {_srcImage->Width(), _srcImage->Height()};
+        _textureSize = {_srcImage->width(), _srcImage->height()};
 
         updateBindOptions(_dirtyBindOptions);
 

--- a/src/qtAliceVision/MSfMData.cpp
+++ b/src/qtAliceVision/MSfMData.cpp
@@ -14,7 +14,7 @@ void SfmDataIORunnable::run()
 
     try
     {
-        if (!aliceVision::sfmDataIO::Load(*sfmData, _sfmDataPath.toLocalFile().toStdString(), aliceVision::sfmDataIO::ESfMData::ALL))
+        if (!aliceVision::sfmDataIO::load(*sfmData, _sfmDataPath.toLocalFile().toStdString(), aliceVision::sfmDataIO::ESfMData::ALL))
         {
             qDebug() << "[QtAliceVision] Failed to load sfmData: " << _sfmDataPath << ".";
         }


### PR DESCRIPTION
This PR updates all the accesses to functions from the SfMDataIO and Image modules, following the changes introduced in https://github.com/alicevision/AliceVision/pull/1637.