### PR TITLE
[qtAliceVision] Update call to `getDistortedPixel` function

### DIFF
--- a/src/qtAliceVision/Surface.cpp
+++ b/src/qtAliceVision/Surface.cpp
@@ -194,7 +194,7 @@ void Surface::computeVerticesGrid(QSGGeometry::TexturedPoint2D* vertices,
             if (isDistortionViewerEnabled() && intrinsic && intrinsic->hasDistortion())
             {
                 const aliceVision::Vec2 undisto_pix(x, y);
-                const aliceVision::Vec2 disto_pix = intrinsic->get_d_pixel(undisto_pix);
+                const aliceVision::Vec2 disto_pix = intrinsic->getDistortedPixel(undisto_pix);
                 vertices[vertexIndex].set(static_cast<float>(disto_pix.x()), static_cast<float>(disto_pix.y()), u, v);
             }
 


### PR DESCRIPTION
Following https://github.com/alicevision/AliceVision/pull/1674, this PR updates the use of `get_d_pixel` to `getDistortedPixel`, as the function has been renamed on AliceVision's side.