### PR TITLE
Fix enums and CMakeLists for Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,6 @@ add_definitions(-DQT_ALICEVISIONIMAGEIO_USE_FORMATS_BLACKLIST)
 
 
 # AliceVision dependency
-add_definitions(-DBOOST_USE_WINAPI_VERSION=BOOST_WINAPI_VERSION_WIN7)
 find_package(AliceVision REQUIRED)
 
 

--- a/src/qtAliceVision/FloatImageViewer.cpp
+++ b/src/qtAliceVision/FloatImageViewer.cpp
@@ -156,10 +156,10 @@ void FloatImageViewer::reload()
         _image.reset();
         setStatus(EStatus::MISSING_FILE);
     }
-    else if (response.error == imgserve::LoadingStatus::ERROR)
+    else if (response.error == imgserve::LoadingStatus::LOADING_ERROR)
     {
         _image.reset();
-        setStatus(EStatus::ERROR);
+        setStatus(EStatus::LOADING_ERROR);
     }
     else if (_outdated)
     {

--- a/src/qtAliceVision/FloatImageViewer.hpp
+++ b/src/qtAliceVision/FloatImageViewer.hpp
@@ -79,7 +79,7 @@ class FloatImageViewer : public QQuickItem
         LOADING,           // an image is being loaded
         OUTDATED_LOADING,  // an image was already loading during the previous reload()
         MISSING_FILE,      // the file to load is missing
-        ERROR              // generic error
+        LOADING_ERROR      // generic error
     };
     Q_ENUM(EStatus)
 

--- a/src/qtAliceVision/ImageServer.hpp
+++ b/src/qtAliceVision/ImageServer.hpp
@@ -18,7 +18,7 @@ enum LoadingStatus
     UNDEFINED,
     SUCCESSFUL,
     MISSING_FILE,
-    ERROR
+    LOADING_ERROR
 };
 
 /**

--- a/src/qtAliceVision/SingleImageLoader.cpp
+++ b/src/qtAliceVision/SingleImageLoader.cpp
@@ -105,7 +105,7 @@ void SingleImageLoadingIORunnable::run()
         }
         else  // "can't open image" case
         {
-            response.error = ERROR;
+            response.error = LOADING_ERROR;
         }
 
         // Log error message


### PR DESCRIPTION
This PR addresses the two following issues on Windows:
- With a recent Boost version (e.g. 1.84.0), building with `BOOST_USE_WINAPI_VERSION` led to linking errors;
- With a recent MCVS compiler, `ERROR` is a keyword that's interpreted as a constant. It thus cannot be used as an enum value anymore. These values are thus renamed to `LOADING_ERROR` for `EStatus` and `LoadingStatus` enumerations.

This relates to https://github.com/alicevision/Meshroom/pull/2491.
