### PR TITLE
Displaying an image is no longer a blocking process

### DIFF
--- a/src/qtAliceVision/AsyncFetcher.cpp
+++ b/src/qtAliceVision/AsyncFetcher.cpp
@@ -15,6 +15,7 @@ AsyncFetcher::AsyncFetcher()
 {
     _resizeRatio = 0.001;
     _isAsynchronous = false;
+    _isPrefetching = false;
     _requestSynchronous = false;
 }
 
@@ -43,6 +44,17 @@ void AsyncFetcher::setResizeRatio(double ratio)
     _resizeRatio = ratio;
 }
 
+void AsyncFetcher::setPrefetching(bool prefetch)
+{
+    _isPrefetching = prefetch;
+
+    if (_isPrefetching)
+    {
+        //Make sure we're not waiting for new source
+        _semLoop.release(1);
+    }
+}
+
 void AsyncFetcher::setCache(ImageCache::uptr&& cache)
 {
     // Cache can't be changed while thread is running
@@ -69,27 +81,34 @@ void AsyncFetcher::run()
             _requestSynchronous = false;
             break;
         }
+        
+        //Lock the thread until someone ask something
+        if (!_semLoop.tryAcquire(1, QDeadlineTimer(1s)))
+        {
+            continue;
+        }
 
         if (_sequence.size() == 0)
         {
-            std::this_thread::sleep_for(100ms);
+            continue;
         }
-        else
+
+        const std::string& lpath = _sequence[static_cast<std::size_t>(_currentIndex)];
+
+        // Load in cache
+        if (_cache)
         {
-            const std::string& lpath = _sequence[static_cast<std::size_t>(_currentIndex)];
-
-            // Load in cache
-            if (_cache)
+            double ratio;
             {
-                double ratio;
-                {
-                    QMutexLocker locker(&_mutexResizeRatio);
-                    ratio = _resizeRatio;
-                }
-
-                _cache->get<image::RGBAfColor>(lpath, static_cast<unsigned int>(_currentIndex), ratio, false);
+                QMutexLocker locker(&_mutexResizeRatio);
+                ratio = _resizeRatio;
             }
 
+            _cache->get<image::RGBAfColor>(lpath, static_cast<unsigned int>(_currentIndex), ratio, false);
+        }
+
+        if (_isPrefetching)
+        {
             _currentIndex++;
 
             int size = static_cast<int>(_sequence.size());
@@ -98,8 +117,10 @@ void AsyncFetcher::run()
                 _currentIndex = 0;
             }
 
-            std::this_thread::sleep_for(1ms);
+            _semLoop.release(1);
         }
+
+        std::this_thread::sleep_for(1ms);
 
         std::size_t cacheSize = getDiskLoads();
         if (cacheSize != previousCacheSize)
@@ -205,7 +226,7 @@ bool AsyncFetcher::getFrame(const std::string& path,
         return false;
     }
 
-    // First try getting the image
+    // Do we only lookup in the cache or do we allow to load on disk immediately
     bool onlyCache = _isAsynchronous;
 
     // Upgrade the thread with the current Index
@@ -218,6 +239,7 @@ bool AsyncFetcher::getFrame(const std::string& path,
         }
     }
 
+    //Try to find in the cache
     std::optional<CacheValue> ovalue = _cache->get<aliceVision::image::RGBAfColor>(path, _currentIndex, _resizeRatio, onlyCache);
 
     if (ovalue.has_value())
@@ -236,6 +258,11 @@ bool AsyncFetcher::getFrame(const std::string& path,
         }
 
         return true;
+    }
+    else 
+    {
+        //If there is no cache, then poke the fetch thread
+        _semLoop.release(1);
     }
 
     return false;

--- a/src/qtAliceVision/AsyncFetcher.hpp
+++ b/src/qtAliceVision/AsyncFetcher.hpp
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QRunnable>
 #include <QMutex>
+#include <QSemaphore>
 #include <QVariantList>
 
 #include "ImageCache.hpp"
@@ -38,6 +39,13 @@ class AsyncFetcher : public QObject, public QRunnable
      * @param ratio the coefficient of resize of the loaded images
      */
     void setResizeRatio(double ratio);
+
+    /**
+     * @brief Do we enable prefetching ? Means that we are prefetching next frames 
+     * in the sequence before asked.
+     * @param prefetch true if prefetching is activated 
+     */
+    void setPrefetching(bool prefetch);
 
     /**
      * @brief retrieve a frame from the cache in both sync and async mode
@@ -102,10 +110,12 @@ class AsyncFetcher : public QObject, public QRunnable
 
     QAtomicInt _currentIndex;
     QAtomicInt _isAsynchronous;
+    QAtomicInt _isPrefetching;
     QAtomicInt _requestSynchronous;
 
     double _resizeRatio;
     QMutex _mutexResizeRatio;
+    QSemaphore _semLoop;
 };
 
 }  // namespace imgserve

--- a/src/qtAliceVision/FloatImageViewer.cpp
+++ b/src/qtAliceVision/FloatImageViewer.cpp
@@ -357,7 +357,7 @@ void FloatImageViewer::setSequence(const QVariantList& paths)
 
 void FloatImageViewer::setFetchingSequence(bool fetching)
 {
-    _sequenceCache.setAsyncFetching(fetching);
+    _sequenceCache.setPrefetching(fetching);
     Q_EMIT fetchingSequenceChanged();
 }
 
@@ -369,6 +369,13 @@ void FloatImageViewer::setResizeRatio(double ratio)
     ratio = std::ceil(ratio * 10.0) / 10.0;
 
     _sequenceCache.setResizeRatio(ratio);
+
+    if (ratio != _clampedResizeRatio)
+    {
+        //If the clamped ratio has changed, then
+        //We may need to reload the image with the correct resolution
+        Q_EMIT sourceChanged();
+    }
 
     _clampedResizeRatio = ratio;
 

--- a/src/qtAliceVision/SequenceCache.cpp
+++ b/src/qtAliceVision/SequenceCache.cpp
@@ -39,8 +39,6 @@ SequenceCache::~SequenceCache()
 
 void SequenceCache::setSequence(const QVariantList& paths)
 {
-    bool isAsync = _fetcher.isAsync();
-
     _fetcher.stopAsync();
     _threadPool.waitForDone();
 
@@ -55,6 +53,7 @@ void SequenceCache::setSequence(const QVariantList& paths)
     _fetcher.setSequence(sequence);
 
     // Restart if needed
+    const bool isAsync = true;
     setAsyncFetching(isAsync);
 }
 
@@ -89,6 +88,11 @@ void SequenceCache::setAsyncFetching(bool fetching)
     }
 }
 
+void SequenceCache::setPrefetching(bool prefetching)
+{
+    _fetcher.setPrefetching(prefetching);
+}
+
 QPointF SequenceCache::getRamInfo() const
 {
     // Get available RAM in bytes and cache occupied memory
@@ -116,6 +120,8 @@ ResponseData SequenceCache::request(const RequestData& reqData)
         return response;
     }
 
+
+    //Build a new response with information fetched
     response.metadata.clear();
     response.img = image;
     response.dim = QSize(static_cast<int>(originalWidth), static_cast<int>(originalHeight));

--- a/src/qtAliceVision/SequenceCache.hpp
+++ b/src/qtAliceVision/SequenceCache.hpp
@@ -52,6 +52,12 @@ class SequenceCache : public QObject, public ImageServer
     void setAsyncFetching(bool fetching);
 
     /**
+     * @brief Set the boolean flag indicating if the sequence is performing prefetching (only if async).
+     * @param[in] prefetching new value for the prefetching flag
+     */
+    void setPrefetching(bool prefetching);
+
+    /**
      * @brief Set the maximum memory that can be filled by the cache.
      * @param[in] memory maximum memory in bytes
      */


### PR DESCRIPTION
- Asynchroneous mode is always activated.
- A prefetch flag is added, which will enable or not the prefetching of frames which are after the currently selected frame.
- QWaitCondition are added to the load loop to avoid unnecessary processing if nothing is to be loaded