### PR TITLE
[qmlSfmData] SfmDataEntity: Handle fixed point size in the shader

### DIFF
--- a/src/qmlSfmData/SfmDataEntity.cpp
+++ b/src/qmlSfmData/SfmDataEntity.cpp
@@ -21,6 +21,7 @@ namespace sfmdataentity {
 
 SfmDataEntity::SfmDataEntity(Qt3DCore::QNode* parent)
   : Qt3DCore::QEntity(parent),
+    _fixedPointSizeParameter(new Qt3DRender::QParameter),
     _pointSizeParameter(new Qt3DRender::QParameter),
     _ioThread(new IOThread())
 {
@@ -35,6 +36,19 @@ void SfmDataEntity::setSource(const QUrl& value)
     _source = value;
     loadSfmData();
     Q_EMIT sourceChanged();
+}
+
+void SfmDataEntity::setFixedPointSize(const bool& value)
+{
+    if (_fixedPointSize == value)
+    {
+        return;
+    }
+
+    _fixedPointSize = value;
+    _fixedPointSizeParameter->setValue(value);
+
+    Q_EMIT fixedPointSizeChanged();
 }
 
 void SfmDataEntity::setPointSize(const float& value)
@@ -182,46 +196,51 @@ void SfmDataEntity::createMaterials()
     technique->graphicsApiFilter()->setProfile(QGraphicsApiFilter::CoreProfile);
 
     shaderProgram->setShaderCode(QShaderProgram::Vertex, R"(#version 450
-    layout(location = 0) in vec3 vertexPosition;
-    layout(location = 1) in vec3 vertexColor;
-    layout(location = 0) out vec3 color;
-    layout(std140, binding = 0) uniform qt3d_render_view_uniforms {
-        mat4 viewMatrix;
-        mat4 projectionMatrix;
-        mat4 uncorrectedProjectionMatrix;
-        mat4 clipCorrectionMatrix;
-        mat4 viewProjectionMatrix;
-        mat4 inverseViewMatrix;
-        mat4 inverseProjectionMatrix;
-        mat4 inverseViewProjectionMatrix;
-        mat4 viewportMatrix;
-        mat4 inverseViewportMatrix;
-        vec4 textureTransformMatrix;
-        vec3 eyePosition;
-        float aspectRatio;
-        float gamma;
-        float exposure;
-        float time;
-    };
-    layout(std140, binding = 1) uniform qt3d_command_uniforms {
-        mat4 modelMatrix;
-        mat4 inverseModelMatrix;
-        mat4 modelViewMatrix;
-        mat3 modelNormalMatrix;
-        mat4 inverseModelViewMatrix;
-        mat4 mvp;
-        mat4 inverseModelViewProjectionMatrix;
-    };
-    layout(std140, binding = 2) uniform custom_ubo {
-        float pointSize;
-    };
+        layout(location = 0) in vec3 vertexPosition;
+        layout(location = 1) in vec3 vertexColor;
+        layout(location = 0) out vec3 color;
+        layout(std140, binding = 0) uniform qt3d_render_view_uniforms {
+            mat4 viewMatrix;
+            mat4 projectionMatrix;
+            mat4 uncorrectedProjectionMatrix;
+            mat4 clipCorrectionMatrix;
+            mat4 viewProjectionMatrix;
+            mat4 inverseViewMatrix;
+            mat4 inverseProjectionMatrix;
+            mat4 inverseViewProjectionMatrix;
+            mat4 viewportMatrix;
+            mat4 inverseViewportMatrix;
+            vec4 textureTransformMatrix;
+            vec3 eyePosition;
+            float aspectRatio;
+            float gamma;
+            float exposure;
+            float time;
+        };
+        layout(std140, binding = 1) uniform qt3d_command_uniforms {
+            mat4 modelMatrix;
+            mat4 inverseModelMatrix;
+            mat4 modelViewMatrix;
+            mat3 modelNormalMatrix;
+            mat4 inverseModelViewMatrix;
+            mat4 mvp;
+            mat4 inverseModelViewProjectionMatrix;
+        };
+        layout(std140, binding = 2) uniform custom_ubo {
+            float pointSize;
+            bool fixedPointSize;
+        };
 
-    void main()
-    {
-        color = vertexColor;
-        gl_Position = mvp * vec4(vertexPosition, 1.0);
-        gl_PointSize = max(viewportMatrix[1][1] * projectionMatrix[1][1] * pointSize / gl_Position.w, 1.0);
-    }
+        void main()
+        {
+            color = vertexColor;
+            gl_Position = mvp * vec4(vertexPosition, 1.0);
+            if (fixedPointSize) {
+                gl_PointSize = pointSize;
+            } else {
+                gl_PointSize = max(viewportMatrix[1][1] * projectionMatrix[1][1] * pointSize * 0.01 / gl_Position.w, 1.0);
+            }
+        }
     )");
 
     shaderProgram->setShaderCode(QShaderProgram::Fragment, R"(#version 450
@@ -232,6 +251,11 @@ void SfmDataEntity::createMaterials()
         fragColor = vec4(color, 1.0);
     }
     )");
+
+    // Add a fixedPointSize uniform
+    _fixedPointSizeParameter->setName("fixedPointSize");
+    _fixedPointSizeParameter->setValue(_fixedPointSize);
+    _cloudMaterial->addParameter(_fixedPointSizeParameter);
 
     // Add a pointSize uniform
     _pointSizeParameter->setName("pointSize");

--- a/src/qmlSfmData/SfmDataEntity.hpp
+++ b/src/qmlSfmData/SfmDataEntity.hpp
@@ -22,6 +22,7 @@ class SfmDataEntity : public Qt3DCore::QEntity
     Q_OBJECT
     Q_PROPERTY(QUrl source READ source WRITE setSource NOTIFY sourceChanged)
     Q_PROPERTY(bool skipHidden MEMBER _skipHidden NOTIFY skipHiddenChanged)
+    Q_PROPERTY(bool fixedPointSize READ fixedPointSize WRITE setFixedPointSize NOTIFY fixedPointSizeChanged)
     Q_PROPERTY(float pointSize READ pointSize WRITE setPointSize NOTIFY pointSizeChanged)
     Q_PROPERTY(float locatorScale READ locatorScale WRITE setLocatorScale NOTIFY locatorScaleChanged)
     Q_PROPERTY(QQmlListProperty<sfmdataentity::CameraLocatorEntity> cameras READ cameras NOTIFY camerasChanged)
@@ -47,12 +48,14 @@ class SfmDataEntity : public Qt3DCore::QEntity
     ~SfmDataEntity() override = default;
 
     Q_SLOT const QUrl& source() const { return _source; }
+    Q_SLOT bool fixedPointSize() const { return _fixedPointSize; }
     Q_SLOT float pointSize() const { return _pointSize; }
     Q_SLOT float locatorScale() const { return _locatorScale; }
     Q_SLOT aliceVision::IndexT selectedViewId() const { return _selectedViewId; }
     Q_SLOT aliceVision::IndexT resectionId() const { return _resectionId; }
     Q_SLOT bool displayResections() const { return _displayResections; }
     Q_SLOT void setSource(const QUrl& source);
+    Q_SLOT void setFixedPointSize(const bool& value);
     Q_SLOT void setPointSize(const float& value);
     Q_SLOT void setLocatorScale(const float& value);
     Q_SLOT void setSelectedViewId(const aliceVision::IndexT& viewId);
@@ -71,6 +74,7 @@ class SfmDataEntity : public Qt3DCore::QEntity
 
     Q_SIGNAL void sourceChanged();
     Q_SIGNAL void camerasChanged();
+    Q_SIGNAL void fixedPointSizeChanged();
     Q_SIGNAL void pointSizeChanged();
     Q_SIGNAL void pointCloudsChanged();
     Q_SIGNAL void locatorScaleChanged();
@@ -100,11 +104,13 @@ class SfmDataEntity : public Qt3DCore::QEntity
     Status _status = SfmDataEntity::None;
     QUrl _source;
     bool _skipHidden = false;
+    bool _fixedPointSize = false;
     float _pointSize = 0.5f;
     float _locatorScale = 1.0f;
     aliceVision::IndexT _selectedViewId = 0;
     aliceVision::IndexT _resectionId = 0;
     bool _displayResections = false;
+    Qt3DRender::QParameter* _fixedPointSizeParameter;
     Qt3DRender::QParameter* _pointSizeParameter;
     Qt3DRender::QMaterial* _cloudMaterial;
     Qt3DRender::QMaterial* _cameraMaterial;


### PR DESCRIPTION
The size of the points in the cloud is now fully handled in the dedicated cloud shader. Prior to this commit, the size of the points in the shader was always determined relatively to the position of the camera. When the `fixedPointSize` option is set, it is now set independently from the camera's position.

The `fixedPointSize` variable is added with its corresponding signal and slot.

Related Meshroom PR: https://github.com/alicevision/Meshroom/pull/2620