### PR TITLE
[qtAliceVision] mTracks can load the content of tracks files

### DIFF
--- a/src/qtAliceVision/FeaturesViewer.cpp
+++ b/src/qtAliceVision/FeaturesViewer.cpp
@@ -338,10 +338,13 @@ void FeaturesViewer::updatePaintTracks(const PaintParams& params, QSGNode* node)
 
         for (const auto& elt : track.elements)
         {
+            aliceVision::IndexT windowSize = static_cast<aliceVision::IndexT>(_timeWindow);
+            aliceVision::IndexT checkId = std::max(currentFrameId, windowSize);
+
             // check that frameId is in timeWindow if enabled
             if (_enableTimeWindow && (_timeWindow >= 0) &&
-                (elt.frameId < currentFrameId - static_cast<aliceVision::IndexT>(_timeWindow) ||
-                 elt.frameId > currentFrameId + static_cast<aliceVision::IndexT>(_timeWindow)))
+                (elt.frameId < checkId - windowSize ||
+                 elt.frameId > currentFrameId + windowSize))
             {
                 continue;
             }

--- a/src/qtAliceVision/MTracks.cpp
+++ b/src/qtAliceVision/MTracks.cpp
@@ -3,6 +3,7 @@
 #include <aliceVision/matching/io.hpp>
 #include <aliceVision/track/TracksBuilder.hpp>
 #include <aliceVision/track/tracksUtils.hpp>
+#include <aliceVision/track/trackIO.hpp>
 
 #include <QDebug>
 #include <QFileInfo>
@@ -42,7 +43,34 @@ void TracksIORunnable::run()
     Q_EMIT resultReady(tracks, tracksPerView);
 }
 
-MTracks::MTracks() { connect(this, &MTracks::matchingFoldersChanged, this, &MTracks::load); }
+void TracksDirectIORunnable::run()
+{
+    aliceVision::track::TracksMap* tracks = new aliceVision::track::TracksMap;
+    aliceVision::track::TracksPerView* tracksPerView = new aliceVision::track::TracksPerView;
+    
+    if (!aliceVision::track::loadTracks(*tracks, _filename))
+    {
+        if (tracks) 
+        {
+            delete tracks;
+        }
+
+        if (tracksPerView)
+        {
+            delete tracksPerView;
+        }
+    }
+
+    aliceVision::track::computeTracksPerView(*tracks, *tracksPerView);
+
+    Q_EMIT resultReady(tracks, tracksPerView);
+}
+
+MTracks::MTracks() 
+{ 
+    connect(this, &MTracks::matchingFoldersChanged, this, &MTracks::load); 
+    connect(this, &MTracks::tracksFileChanged, this, &MTracks::loadDirect); 
+}
 
 MTracks::~MTracks()
 {
@@ -84,6 +112,32 @@ void MTracks::load()
 
     TracksIORunnable* ioRunnable = new TracksIORunnable(folders);
     connect(ioRunnable, &TracksIORunnable::resultReady, this, &MTracks::onReady);
+    QThreadPool::globalInstance()->start(ioRunnable);
+}
+
+void MTracks::loadDirect()
+{
+    _needReload = false;
+
+    if (_status == Loading)
+    {
+        qDebug("[QtAliceVision] Tracks: Unable to load, a load event is already running.");
+        _needReload = true;
+        return;
+    }
+
+    if (_tracksFile.isEmpty())
+    {
+        setStatus(None);
+        return;
+    }
+
+    setStatus(Loading);
+
+    std::string path = _tracksFile.toString().toStdString();
+
+    TracksDirectIORunnable* ioRunnable = new TracksDirectIORunnable(path);
+    connect(ioRunnable, &TracksDirectIORunnable::resultReady, this, &MTracks::onReady);
     QThreadPool::globalInstance()->start(ioRunnable);
 }
 

--- a/src/qtAliceVision/MTracks.hpp
+++ b/src/qtAliceVision/MTracks.hpp
@@ -32,8 +32,10 @@ class MTracks : public QObject
     // Path to folder containing the matches
     Q_PROPERTY(QVariantList matchingFolders MEMBER _matchingFolders NOTIFY matchingFoldersChanged)
 
-    /// Status
+    /// Path to 
+    Q_PROPERTY(QUrl tracksFile MEMBER _tracksFile NOTIFY tracksFileChanged)
 
+    /// Status
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
 
   public:
@@ -59,11 +61,13 @@ class MTracks : public QObject
     /// Slots
 
     Q_SLOT void load();
+    Q_SLOT void loadDirect();
     Q_SLOT void onReady(aliceVision::track::TracksMap* tracks, aliceVision::track::TracksPerView* tracksPerView);
 
     /// Signals
 
     Q_SIGNAL void matchingFoldersChanged();
+    Q_SIGNAL void tracksFileChanged();
     Q_SIGNAL void tracksChanged();
     Q_SIGNAL void statusChanged(Status status);
 
@@ -83,6 +87,7 @@ class MTracks : public QObject
     /// Private members
 
     QVariantList _matchingFolders;
+    QUrl _tracksFile;
 
     aliceVision::track::TracksMap* _tracks = nullptr;
     aliceVision::track::TracksPerView* _tracksPerView = nullptr;
@@ -109,6 +114,26 @@ class TracksIORunnable : public QObject, public QRunnable
 
   private:
     std::vector<std::string> _folders;
+};
+
+/**
+ * @brief QRunnable object dedicated to loading tracks using AliceVision.
+ */
+class TracksDirectIORunnable : public QObject, public QRunnable
+{
+    Q_OBJECT
+
+  public:
+    explicit TracksDirectIORunnable(const std::string& filename)
+      : _filename(filename)
+    {}
+
+    Q_SLOT void run() override;
+
+    Q_SIGNAL void resultReady(aliceVision::track::TracksMap* tracks, aliceVision::track::TracksPerView* tracksPerView);
+
+  private:
+    std::string _filename;
 };
 
 }  // namespace qtAliceVision


### PR DESCRIPTION
This PR enable the loading and display of tracks in the experimental pipeline (using pre computed json tracks files).

See also https://github.com/alicevision/Meshroom/pull/2720