### PR TITLE
All QT properties have either READ or MEMBER information

### DIFF
--- a/src/qtAliceVision/AsyncFetcher.cpp
+++ b/src/qtAliceVision/AsyncFetcher.cpp
@@ -55,6 +55,11 @@ void AsyncFetcher::setPrefetching(bool prefetch)
     }
 }
 
+bool AsyncFetcher::getPrefetching()
+{
+    return _isPrefetching;
+}
+
 void AsyncFetcher::setCache(ImageCache::uptr&& cache)
 {
     // Cache can't be changed while thread is running
@@ -144,9 +149,19 @@ void AsyncFetcher::updateCacheMemory(std::size_t maxMemory)
     }
 }
 
-std::size_t AsyncFetcher::getCacheSize() const { return (_cache) ? static_cast<std::size_t>(_cache->info().getContentSize()) : 0; }
+std::size_t AsyncFetcher::getCacheMemory()
+{
+    return (_cache)?_cache->getMaxMemory():0;
+}
 
-std::size_t AsyncFetcher::getDiskLoads() const { return (_cache) ? static_cast<std::size_t>(_cache->info().getLoadFromDisk()) : 0; }
+std::size_t AsyncFetcher::getCacheSize() const 
+{
+    return (_cache) ? static_cast<std::size_t>(_cache->info().getContentSize()) : 0; 
+}
+
+std::size_t AsyncFetcher::getDiskLoads() const { 
+    return (_cache) ? static_cast<std::size_t>(_cache->info().getLoadFromDisk()) : 0; 
+}
 
 QVariantList AsyncFetcher::getCachedFrames() const
 {

--- a/src/qtAliceVision/AsyncFetcher.hpp
+++ b/src/qtAliceVision/AsyncFetcher.hpp
@@ -48,6 +48,13 @@ class AsyncFetcher : public QObject, public QRunnable
     void setPrefetching(bool prefetch);
 
     /**
+     * @brief Do we enable prefetching ? Means that we are prefetching next frames
+     * in the sequence before asked.
+     * @return true if prefetching is activated
+     */
+    bool getPrefetching();
+
+    /**
      * @brief retrieve a frame from the cache in both sync and async mode
      * @param path the image path which should be contained in _sequence.
      * @param image the result image pointer
@@ -96,6 +103,12 @@ class AsyncFetcher : public QObject, public QRunnable
      * @param maxMemory the number of bytes allowed in the cache
      */
     void updateCacheMemory(std::size_t maxMemory);
+
+    /**
+     * @brief update maxMemory for the cache
+     * @return the number of bytes allowed in the cache
+     */
+    std::size_t getCacheMemory();
 
     /**
      * @brief get a list of regions containing the image frames

--- a/src/qtAliceVision/FloatImageViewer.cpp
+++ b/src/qtAliceVision/FloatImageViewer.cpp
@@ -362,7 +362,10 @@ void FloatImageViewer::setFetchingSequence(bool fetching)
     Q_EMIT fetchingSequenceChanged();
 }
 
-void FloatImageViewer::setTargetSize(int size) {}
+bool FloatImageViewer::getFetchingSequence()
+{
+    return _sequenceCache.getPrefetching();
+}
 
 void FloatImageViewer::setResizeRatio(double ratio)
 {
@@ -383,15 +386,31 @@ void FloatImageViewer::setResizeRatio(double ratio)
     Q_EMIT resizeRatioChanged();
 }
 
+double FloatImageViewer::getResizeRatio()
+{
+    return _clampedResizeRatio;
+}
+
 void FloatImageViewer::setMemoryLimit(int memoryLimit)
 {
     _sequenceCache.setMemoryLimit(memoryLimit);
     Q_EMIT memoryLimitChanged();
 }
 
-QVariantList FloatImageViewer::getCachedFrames() const { return _sequenceCache.getCachedFrames(); }
+int FloatImageViewer::getMemoryLimit()
+{
+    return _sequenceCache.getMemoryLimit();
+}
 
-QPointF FloatImageViewer::getRamInfo() const { return _sequenceCache.getRamInfo(); }
+QVariantList FloatImageViewer::getCachedFrames() const
+{ 
+    return _sequenceCache.getCachedFrames(); 
+}
+
+QPointF FloatImageViewer::getRamInfo() const 
+{ 
+    return _sequenceCache.getRamInfo(); 
+}
 
 void FloatImageViewer::reload()
 {
@@ -568,8 +587,8 @@ QSGNode* FloatImageViewer::updatePaintNode(QSGNode* oldNode, [[maybe_unused]] QQ
     {
         _boundingRect = newBoundingRect;
 
-        const float windowRatio = static_cast<float>(_boundingRect.width() / _boundingRect.height());
-        const float textureRatio = _textureSize.width() / float(_textureSize.height());
+        const float windowRatio = static_cast<float>(_boundingRect.width()) / static_cast<float>(_boundingRect.height());
+        const float textureRatio = static_cast<float>(_textureSize.width()) / static_cast<float>(_textureSize.height());
         QRectF geometryRect = _boundingRect;
         if (windowRatio > textureRatio)
         {
@@ -617,6 +636,8 @@ QSGNode* FloatImageViewer::updatePaintNode(QSGNode* oldNode, [[maybe_unused]] QQ
                 break;
             case EChannelMode::A:
                 channelOrder = QVector4D(3.f, 3.f, 3.f, -1.f);
+                break;
+            default:
                 break;
         }
         node->setChannelOrder(channelOrder);

--- a/src/qtAliceVision/FloatImageViewer.hpp
+++ b/src/qtAliceVision/FloatImageViewer.hpp
@@ -52,19 +52,17 @@ class FloatImageViewer : public QQuickItem
 
     Q_PROPERTY(bool cropFisheye READ getCropFisheye WRITE setCropFisheye NOTIFY isCropFisheyeChanged)
 
-    Q_PROPERTY(QVariantList sequence WRITE setSequence NOTIFY sequenceChanged)
+    Q_PROPERTY(QVariantList sequence MEMBER _sequence WRITE setSequence NOTIFY sequenceChanged)
 
-    Q_PROPERTY(int targetSize WRITE setTargetSize NOTIFY targetSizeChanged)
-
-    Q_PROPERTY(double resizeRatio WRITE setResizeRatio NOTIFY resizeRatioChanged)
+    Q_PROPERTY(double resizeRatio READ getResizeRatio WRITE setResizeRatio NOTIFY resizeRatioChanged)
 
     Q_PROPERTY(QVariantList cachedFrames READ getCachedFrames NOTIFY cachedFramesChanged)
 
     Q_PROPERTY(bool useSequence MEMBER _useSequence NOTIFY useSequenceChanged)
 
-    Q_PROPERTY(bool fetchingSequence WRITE setFetchingSequence NOTIFY fetchingSequenceChanged)
+    Q_PROPERTY(bool fetchingSequence READ getFetchingSequence WRITE setFetchingSequence NOTIFY fetchingSequenceChanged)
 
-    Q_PROPERTY(int memoryLimit WRITE setMemoryLimit NOTIFY memoryLimitChanged)
+    Q_PROPERTY(int memoryLimit READ getMemoryLimit WRITE setMemoryLimit NOTIFY memoryLimitChanged)
 
     Q_PROPERTY(QPointF ramInfo READ getRamInfo NOTIFY cachedFramesChanged)
 
@@ -151,13 +149,17 @@ class FloatImageViewer : public QQuickItem
 
     void setSequence(const QVariantList& paths);
 
-    void setTargetSize(int size);
-
     void setResizeRatio(double ratio);
+
+    double getResizeRatio();
 
     void setFetchingSequence(bool fetching);
 
+    bool getFetchingSequence();
+
     void setMemoryLimit(int memoryLimit);
+
+    int getMemoryLimit();
 
     QVariantList getCachedFrames() const;
 
@@ -210,6 +212,7 @@ class FloatImageViewer : public QQuickItem
     imgserve::SingleImageLoader _singleImageLoader;
     bool _useSequence = true;
     double _clampedResizeRatio = 1.0;
+    QVariantList _sequence;
 };
 
 }  // namespace qtAliceVision

--- a/src/qtAliceVision/ImageCache.cpp
+++ b/src/qtAliceVision/ImageCache.cpp
@@ -83,8 +83,19 @@ void ImageCache::cleanup(size_t requestedSize, const CacheKey& toAdd)
     }
 }
 
-void ImageCache::updateMaxMemory(unsigned long long int maxSize) { _info.setMaxMemory(maxSize); }
+void ImageCache::updateMaxMemory(unsigned long long int maxSize) 
+{ 
+    _info.setMaxMemory(maxSize); 
+}
 
-void ImageCache::setReferenceFrameId(int referenceFrameId) { _referenceFrameId = referenceFrameId; }
+unsigned long long int ImageCache::getMaxMemory()
+{
+    return _info.getCapacity();
+}
+
+void ImageCache::setReferenceFrameId(int referenceFrameId) 
+{ 
+    _referenceFrameId = referenceFrameId; 
+}
 
 }  // namespace qtAliceVision

--- a/src/qtAliceVision/ImageCache.hpp
+++ b/src/qtAliceVision/ImageCache.hpp
@@ -296,6 +296,12 @@ class ImageCache
     void updateMaxMemory(unsigned long long int maxSize);
 
     /**
+     * @brief get the cache max memory
+     * @return the cache max memory
+    */
+    unsigned long long int getMaxMemory();
+
+    /**
      * @brief set the reference frame ID
      * @param referenceFrameId the value to store
      */

--- a/src/qtAliceVision/SequenceCache.cpp
+++ b/src/qtAliceVision/SequenceCache.cpp
@@ -57,9 +57,20 @@ void SequenceCache::setSequence(const QVariantList& paths)
     setAsyncFetching(isAsync);
 }
 
-void SequenceCache::setResizeRatio(double ratio) { _fetcher.setResizeRatio(ratio); }
+void SequenceCache::setResizeRatio(double ratio) 
+{ 
+    _fetcher.setResizeRatio(ratio); 
+}
 
-void SequenceCache::setMemoryLimit(int memory)
+std::size_t SequenceCache::getMemoryLimit()
+{
+    // Convert parameter in gigabytes to bytes
+    const double gigaBytesToBytes = 1024. * 1024. * 1024.;
+    const size_t memory = _fetcher.getCacheMemory();
+    return static_cast<std::size_t>(static_cast<double>(memory) / gigaBytesToBytes);
+}
+
+void SequenceCache::setMemoryLimit(std::size_t memory)
 {
     // Convert parameter in gigabytes to bytes
     const double gigaBytesToBytes = 1024. * 1024. * 1024.;
@@ -82,7 +93,15 @@ void SequenceCache::setAsyncFetching(bool fetching)
     }
 }
 
-void SequenceCache::setPrefetching(bool prefetching) { _fetcher.setPrefetching(prefetching); }
+void SequenceCache::setPrefetching(bool prefetching) 
+{ 
+    _fetcher.setPrefetching(prefetching); 
+}
+
+bool SequenceCache::getPrefetching()
+{
+    return _fetcher.getPrefetching();
+}
 
 QPointF SequenceCache::getRamInfo() const
 {

--- a/src/qtAliceVision/SequenceCache.hpp
+++ b/src/qtAliceVision/SequenceCache.hpp
@@ -58,10 +58,22 @@ class SequenceCache : public QObject, public ImageServer
     void setPrefetching(bool prefetching);
 
     /**
-     * @brief Set the maximum memory that can be filled by the cache.
-     * @param[in] memory maximum memory in bytes
+     * @brief Get the boolean flag indicating if the sequence is performing prefetching (only if async).
+     * @return true if prefetching
+    */
+   bool getPrefetching();
+
+    /**
+     * @brief Get the maximum memory that can be filled by the cache.
+     * @return memory maximum memory in gigabytes
      */
-    void setMemoryLimit(int memory);
+    std::size_t getMemoryLimit();
+
+    /**
+     * @brief Set the maximum memory that can be filled by the cache.
+     * @param[in] memory maximum memory in gigabytes
+     */
+    void setMemoryLimit(std::size_t memory);
 
     /**
      * @brief Get the maximum available RAM on the system.


### PR DESCRIPTION
Mostly consist in adding MEMBER information to properties of FloatImageViewer.

Various warnings removed

see https://github.com/alicevision/Meshroom/pull/2746
