### PR TITLE
Avoid performance issues while reading images

### DIFF
--- a/src/qtAliceVision/ImageCache.cpp
+++ b/src/qtAliceVision/ImageCache.cpp
@@ -6,7 +6,14 @@ ImageCache::ImageCache(unsigned long maxSize, const aliceVision::image::ImageRea
   : _info(maxSize),
     _options(options),
     _referenceFrameId(0)
-{}
+{
+    //Use 4 threads max, but less if we don't have this
+    int count = std::min(4, omp_get_max_threads());
+
+    //Setup openimageio
+    oiio::attribute("threads", count);
+    oiio::attribute("exr_threads", count);
+}
 
 ImageCache::~ImageCache() {}
 


### PR DESCRIPTION
Meshroom was getting very laggy while reading images with recent oiio.

Limit the number of threads used for sequence reading so that meshroom keep being able to work.

Thread optimization and OpenImageIO setup:

* [`src/qtAliceVision/ImageCache.cpp`](diffhunk://#diff-d67e54616f5ed1d0541d1f373f9aee3f097eaef246c726faf8f8b4a8b5088fa4L9-R16): Updated the `ImageCache` constructor to configure OpenImageIO to use up to 4 threads, or fewer if the system has fewer available threads. This is achieved using `oiio::attribute` for both general threads and EXR-specific threads.