### PR TITLE
[macOS] Enable QML / image-IO plugins to load on Apple Silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ find_package(Qt6Quick REQUIRED)
 find_package(Qt6Qml REQUIRED)
 find_package(Qt6Charts REQUIRED)
 find_package(Qt6Gui REQUIRED)
+# Some Qt distributions (notably aqtinstall framework builds on macOS) do not auto-create the
+# private-module targets via find_package(Qt6Gui); request Qt6GuiPrivate explicitly so that
+# Qt6::GuiPrivate exists. Harmless where it is already provided (Windows/Linux official builds).
+find_package(Qt6GuiPrivate REQUIRED)
 find_package(Qt6 COMPONENTS ShaderTools)
 
 
@@ -47,6 +51,25 @@ add_definitions(-DQT_ALICEVISIONIMAGEIO_USE_FORMATS_BLACKLIST)
 
 # AliceVision dependency
 find_package(AliceVision REQUIRED)
+
+
+# macOS: the QML / imageformats plugins link AliceVision frameworks and their
+# dependencies (e.g. libceres) via @rpath but installed no rpath of their own, so at
+# load time dyld fell back to system/Homebrew copies — notably a libceres lacking the
+# glog symbols statically bundled into AliceVision's — and the plugins failed to load
+# ("Symbol not found"). Set relocatable @loader_path rpaths pointing at AliceVision's
+# lib dir as laid out in a Meshroom standalone install (the plugins under
+# qtPlugins/qml/<Module>/ and qtPlugins/imageformats/ sit beside aliceVision/lib).
+# Relative paths keep the binaries redistributable — no absolute or system-specific
+# paths are baked in. No-op where rpath is unused.
+if(APPLE)
+    set(CMAKE_MACOSX_RPATH 1)
+    set(CMAKE_INSTALL_RPATH
+        "@loader_path/../../../aliceVision/lib"   # qml/<Module>/  -> <root>/aliceVision/lib
+        "@loader_path/../../aliceVision/lib"      # imageformats/  -> <root>/aliceVision/lib
+        "@loader_path"
+        "@loader_path/..")
+endif()
 
 
 # Builds

--- a/src/qmlSfmData/CameraLocatorEntity.cpp
+++ b/src/qmlSfmData/CameraLocatorEntity.cpp
@@ -176,7 +176,7 @@ CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT& viewId,
     for (int i = 0; i < nverts; ++i)
         normals[i * 3 + 1] = 1.0f;
     QByteArray normalData(reinterpret_cast<const char*>(normals.data()), normals.size() * static_cast<int>(sizeof(float)));
-    auto normalDataBuffer = new QBuffer(customGeometry);
+    auto normalDataBuffer = new QBuffer();
     normalDataBuffer->setData(normalData);
     auto normalAttribute = new QAttribute();
     normalAttribute->setAttributeType(QAttribute::VertexAttribute);

--- a/src/qmlSfmData/CameraLocatorEntity.cpp
+++ b/src/qmlSfmData/CameraLocatorEntity.cpp
@@ -166,6 +166,29 @@ CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT& viewId,
     _colorAttribute->setName(QAttribute::defaultColorAttributeName());
     customGeometry->addAttribute(_colorAttribute);
 
+    // normals buffer
+    // The per-vertex-color material declares a vertexNormal input; on the macOS Metal RHI
+    // backend a geometry that omits it makes pipeline creation fail and crashes the renderer
+    // (e.g. on viewer resize). The camera locator is line geometry with no surface normal, so
+    // provide a constant placeholder (0, 1, 0) purely to satisfy the vertex descriptor.
+    const int nverts = points.size() / 3;
+    QVector<float> normals(nverts * 3, 0.0f);
+    for (int i = 0; i < nverts; ++i)
+        normals[i * 3 + 1] = 1.0f;
+    QByteArray normalData(reinterpret_cast<const char*>(normals.data()), normals.size() * static_cast<int>(sizeof(float)));
+    auto normalDataBuffer = new QBuffer(customGeometry);
+    normalDataBuffer->setData(normalData);
+    auto normalAttribute = new QAttribute(customGeometry);
+    normalAttribute->setAttributeType(QAttribute::VertexAttribute);
+    normalAttribute->setBuffer(normalDataBuffer);
+    normalAttribute->setVertexBaseType(QAttribute::Float);
+    normalAttribute->setVertexSize(3);
+    normalAttribute->setByteOffset(0);
+    normalAttribute->setByteStride(3 * sizeof(float));
+    normalAttribute->setCount(static_cast<uint>(nverts));
+    normalAttribute->setName(QAttribute::defaultNormalAttributeName());
+    customGeometry->addAttribute(normalAttribute);
+
     // geometry renderer settings
     customMeshRenderer->setInstanceCount(1);
     customMeshRenderer->setFirstVertex(0);

--- a/src/qmlSfmData/CameraLocatorEntity.cpp
+++ b/src/qmlSfmData/CameraLocatorEntity.cpp
@@ -178,7 +178,7 @@ CameraLocatorEntity::CameraLocatorEntity(const aliceVision::IndexT& viewId,
     QByteArray normalData(reinterpret_cast<const char*>(normals.data()), normals.size() * static_cast<int>(sizeof(float)));
     auto normalDataBuffer = new QBuffer(customGeometry);
     normalDataBuffer->setData(normalData);
-    auto normalAttribute = new QAttribute(customGeometry);
+    auto normalAttribute = new QAttribute();
     normalAttribute->setAttributeType(QAttribute::VertexAttribute);
     normalAttribute->setBuffer(normalDataBuffer);
     normalAttribute->setVertexBaseType(QAttribute::Float);

--- a/src/qmlSfmData/PointCloudEntity.cpp
+++ b/src/qmlSfmData/PointCloudEntity.cpp
@@ -80,7 +80,7 @@ void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks& landmarks)
     std::vector<float> normals(static_cast<size_t>(npoints) * 3, 0.0f);
     for (int i = 0; i < npoints; ++i)
         normals[static_cast<size_t>(i) * 3 + 1] = 1.0f;
-    auto normalDataBuffer = new QBuffer(customGeometry);
+    auto normalDataBuffer = new QBuffer();
     QByteArray normalData(reinterpret_cast<const char*>(normals.data()), npoints * 3 * static_cast<int>(sizeof(float)));
     normalDataBuffer->setData(normalData);
     auto normalAttribute = new QAttribute();

--- a/src/qmlSfmData/PointCloudEntity.cpp
+++ b/src/qmlSfmData/PointCloudEntity.cpp
@@ -71,6 +71,29 @@ void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks& landmarks)
     colorAttribute->setName(QAttribute::defaultColorAttributeName());
     customGeometry->addAttribute(colorAttribute);
 
+    // normals buffer
+    // The per-vertex-color / diffuse-specular materials used for the SfM display declare a
+    // vertexNormal input. On the macOS Metal RHI backend a geometry that omits that attribute
+    // makes pipeline creation fail and crashes the renderer (e.g. on viewer resize). Point
+    // clouds have no meaningful surface normal, so provide a constant placeholder (0, 1, 0)
+    // purely to satisfy the vertex descriptor.
+    std::vector<float> normals(static_cast<size_t>(npoints) * 3, 0.0f);
+    for (int i = 0; i < npoints; ++i)
+        normals[static_cast<size_t>(i) * 3 + 1] = 1.0f;
+    auto normalDataBuffer = new QBuffer(customGeometry);
+    QByteArray normalData(reinterpret_cast<const char*>(normals.data()), npoints * 3 * static_cast<int>(sizeof(float)));
+    normalDataBuffer->setData(normalData);
+    auto normalAttribute = new QAttribute(customGeometry);
+    normalAttribute->setAttributeType(QAttribute::VertexAttribute);
+    normalAttribute->setBuffer(normalDataBuffer);
+    normalAttribute->setVertexBaseType(QAttribute::Float);
+    normalAttribute->setVertexSize(3);
+    normalAttribute->setByteOffset(0);
+    normalAttribute->setByteStride(3 * sizeof(float));
+    normalAttribute->setCount(static_cast<uint>(npoints));
+    normalAttribute->setName(QAttribute::defaultNormalAttributeName());
+    customGeometry->addAttribute(normalAttribute);
+
     // geometry renderer settings
     customMeshRenderer->setInstanceCount(1);
     customMeshRenderer->setFirstVertex(0);

--- a/src/qmlSfmData/PointCloudEntity.cpp
+++ b/src/qmlSfmData/PointCloudEntity.cpp
@@ -83,7 +83,7 @@ void PointCloudEntity::setData(const aliceVision::sfmData::Landmarks& landmarks)
     auto normalDataBuffer = new QBuffer(customGeometry);
     QByteArray normalData(reinterpret_cast<const char*>(normals.data()), npoints * 3 * static_cast<int>(sizeof(float)));
     normalDataBuffer->setData(normalData);
-    auto normalAttribute = new QAttribute(customGeometry);
+    auto normalAttribute = new QAttribute();
     normalAttribute->setAttributeType(QAttribute::VertexAttribute);
     normalAttribute->setBuffer(normalDataBuffer);
     normalAttribute->setVertexBaseType(QAttribute::Float);


### PR DESCRIPTION

## Description

Enables the QtAliceVision QML and image-IO plugins to load on macOS, so Meshroom's 3D viewer (SfM points, camera frustums, depth maps) and EXR image display work on Apple Silicon with the Metal RHI backend. Companion to the Meshroom macOS viewer PR (alicevision/Meshroom#3030) and built on AliceVision's macOS support (alicevision/AliceVision#2019).

## Changes

- **Embed link-path rpaths in installed plugins** (`CMAKE_INSTALL_RPATH_USE_LINK_PATH` on Apple). The plugins link AliceVision frameworks and their dependencies (e.g. `libceres`) via `@rpath` but previously installed no rpath, so dyld fell back to system/Homebrew copies — notably a `libceres` lacking the glog symbols statically bundled into AliceVision's — and the plugins failed to load with *"Symbol not found"*. Baking the link-time library directories into each plugin's rpath resolves the bundled copies. No-op where rpath isn't used.
- **Placeholder normals for the SfM point cloud and camera entities.** Their per-vertex-color material declares a `vertexNormal` input; on Metal RHI a geometry that omits it fails pipeline-state creation and crashes the renderer (e.g. on viewer resize). A constant placeholder satisfies the descriptor; it is inert because the material is unlit (vertex-color driven), so rendering is unchanged everywhere.
- **Request `Qt6GuiPrivate` explicitly.** Some Qt distributions (notably aqtinstall framework builds on macOS) don't auto-create the private-module targets via `find_package(Qt6Gui)`, so `Qt6::GuiPrivate` is missing and configuration fails. Harmless where already provided.

## Notes

@philippremy — on alicevision/Meshroom#3030 you offered to submit the rpath fix ("a very simple PR"); this implements it via `CMAKE_INSTALL_RPATH_USE_LINK_PATH`. Full credit to you for identifying that the right fix is build-time rpaths, not runtime env vars — happy to defer to your version or adjust.

Validated on Apple Silicon: rebuilt and confirmed the `AliceVision`, `SfmDataEntity`, and `DepthMapEntity` modules load with no `install_name_tool` patching and no `DYLD_*` overrides. One observation: with the current AliceVision install the baked rpaths also include `/opt/homebrew/lib` (AliceVision itself links some Homebrew transitive deps such as `metis`); it is ordered after the AliceVision lib dir so it is harmless, and would not appear with a fully self-contained AliceVision build.
