### PR TITLE
[docker] add dockerfile for qt-av-deps image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,5 @@
 compile_commands.json
 
 # Build directories
-build*
-dist*
+build*/
+dist*/

--- a/docker/Dockerfile_rocky
+++ b/docker/Dockerfile_rocky
@@ -29,6 +29,7 @@ RUN dnf -y install epel-release && \
         mesa-libGL-devel \
         mesa-libEGL-devel \
         libxkbcommon-devel \
+        libxkbcommon-x11 \
         fontconfig-devel \
         freetype-devel \
         libX11-devel \
@@ -37,6 +38,8 @@ RUN dnf -y install epel-release && \
         libxcb-devel \
         xcb-util-renderutil-devel \
         xcb-util-image-devel \
+        xcb-util-cursor \
+        xcb-util-keysyms \
         libXi-devel \
         libXcomposite-devel \
         libXcursor-devel \
@@ -46,6 +49,7 @@ RUN dnf -y install epel-release && \
         libXtst-devel \
         dbus-devel \
         glib2-devel \
+        wayland-devel \
         # CMake & Ninja for building Qt projects
         cmake \
         ninja-build \

--- a/docker/Dockerfile_rocky
+++ b/docker/Dockerfile_rocky
@@ -74,7 +74,8 @@ RUN aqt list-qt linux desktop
 ARG QT_VERSION=6.11.1
 ARG QT_ARCH=linux_gcc_64
 ARG QT_ARCH_SHORT=gcc_64
-ARG QT_MODULES="qtcharts qt3d qtshadertools"
+# A dependency of Qt requires qttasktree but not explicitely, so we need to force the installation.
+ARG QT_MODULES="qtcharts qt3d qtshadertools qttasktree"
 ARG QT_DIR=/opt/Qt
 
 RUN if [ -n "${QT_MODULES}" ]; then \

--- a/docker/Dockerfile_rocky
+++ b/docker/Dockerfile_rocky
@@ -1,0 +1,105 @@
+# Rocky Linux + Qt via aqtinstall
+# Usage:
+#   docker build --build-arg QT_VERSION=6.11.1 -t rocky-qt .
+#   docker run --rm -it rocky-qt bash
+#
+# Override defaults at build time:
+#   --build-arg QT_VERSION=6.11.1
+#   --build-arg QT_ARCH=gcc_64
+#   --build-arg QT_MODULES="qtcharts qt3d qtshadertools"
+
+ARG AVDEPS_VERSION=2026.03.30
+ARG CUDA_VERSION=12.1.1
+ARG ROCKY_VERSION=9
+# FROM rockylinux:${ROCKY_VERSION}
+# FROM nvidia/cuda:${CUDA_VERSION}-devel-rockylinux${ROCKY_VERSION}
+FROM alicevision/alicevision-deps:${AVDEPS_VERSION}-rocky${ROCKY_VERSION}-cuda${CUDA_VERSION}
+
+# ── System dependencies ────────────────────────────────────────────────────────
+# CRB (CodeReady Builder) is required for several *-devel packages
+# RUN dnf -y update
+RUN dnf -y install epel-release && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y groupinstall "Development Tools" && \
+    dnf -y install \
+        # Python / pip (needed by aqtinstall)
+        python3 \
+        python3-pip \
+        # Qt runtime / build dependencies
+        mesa-libGL-devel \
+        mesa-libEGL-devel \
+        libxkbcommon-devel \
+        fontconfig-devel \
+        freetype-devel \
+        libX11-devel \
+        libXext-devel \
+        libXrender-devel \
+        libxcb-devel \
+        xcb-util-renderutil-devel \
+        xcb-util-image-devel \
+        libXi-devel \
+        libXcomposite-devel \
+        libXcursor-devel \
+        libXdamage-devel \
+        libXfixes-devel \
+        libXrandr-devel \
+        libXtst-devel \
+        dbus-devel \
+        glib2-devel \
+        # CMake & Ninja for building Qt projects
+        cmake \
+        ninja-build \
+        # Misc utilities
+        wget \
+        git \
+    && dnf clean all
+
+# ── Install aqtinstall ─────────────────────────────────────────────────────────
+RUN pip3 install --upgrade pip && \
+    pip3 install aqtinstall
+
+# ── Install Qt ────────────────────────────────────────────────────────────────
+
+# List available versions
+RUN aqt list-qt linux desktop
+
+# List available modules
+# RUN aqt list-qt linux desktop --modules "${QT_VERSION}" "${QT_ARCH}"
+
+# ── Build arguments ────────────────────────────────────────────────────────────
+ARG QT_VERSION=6.11.1
+ARG QT_ARCH=linux_gcc_64
+ARG QT_ARCH_SHORT=gcc_64
+ARG QT_MODULES="qtcharts qt3d qtshadertools"
+ARG QT_DIR=/opt/Qt
+
+RUN if [ -n "${QT_MODULES}" ]; then \
+        aqt install-qt \
+            --outputdir "${QT_DIR}" \
+            linux desktop "${QT_VERSION}" "${QT_ARCH}" \
+            -m ${QT_MODULES}; \
+    else \
+        aqt install-qt \
+            --outputdir "${QT_DIR}" \
+            linux desktop "${QT_VERSION}" "${QT_ARCH}"; \
+    fi
+
+# ── Environment variables ─────────────────────────────────────────────────────
+ENV QT_ROOT="${QT_DIR}/${QT_VERSION}/${QT_ARCH_SHORT}"
+ENV PATH="${QT_ROOT}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${QT_ROOT}/lib:${LD_LIBRARY_PATH}"
+ENV CMAKE_PREFIX_PATH="${QT_ROOT}"
+ENV QT_PLUGIN_PATH="${QT_ROOT}/plugins"
+ENV QML2_IMPORT_PATH="${QT_ROOT}/qml"
+ENV QML_IMPORT_PATH="${QML2_IMPORT_PATH}"
+
+# ── Smoke test ────────────────────────────────────────────────────────────────
+RUN ls -l ${QT_ROOT}/lib
+RUN find ${QT_DIR} -name "libQt6*.so*"
+RUN echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
+RUN ldd ${QT_ROOT}/bin/qmake
+
+RUN qmake --version && cmake --version
+
+WORKDIR /workspace
+CMD ["bash"]

--- a/docker/build-rocky.sh
+++ b/docker/build-rocky.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+AVDEPS_VERSION=2026.03.30
+ROCKY_VERSION=9
+CUDA_VERSION=12.1.1
+QT_VERSION=6.11.1  # 6.11.1 6.10.3 6.9.3 6.8.3
+
+DOCKER_TAG=alicevision/qt-av-deps:qt${QT_VERSION}-avdeps${AVDEPS_VERSION}-rocky${ROCKY_VERSION}-cuda${CUDA_VERSION}
+
+docker build \
+    --rm \
+    --progress=plain \
+    --build-arg "QT_VERSION=${QT_VERSION}" \
+    --tag "${DOCKER_TAG}" \
+    -f Dockerfile_rocky .
+
+echo "# To launch the docker image:"
+echo docker run -it ${DOCKER_TAG} /bin/bash
+
+


### PR DESCRIPTION
Dockerfile for building an image containing Qt and avdeps (AliceVision dependencies only). This image is required to set up the CI pipeline for QtAliceVision.